### PR TITLE
feat(infra): SQLite + Keycloak + Dockerfile + docker-compose + LeoCloud

### DIFF
--- a/.github/workflows/Backend.yaml
+++ b/.github/workflows/Backend.yaml
@@ -1,0 +1,75 @@
+name: Backend(ClimbConnect) Docker (for LeoCloud)
+
+env:
+  ContainerName: climbconnectapi
+  CloudNameSpace: student-r-lehner
+  AppPrefix: climbconnectapi
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "backend/**"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend/ClimbConnect.API
+          file: ./backend/ClimbConnect.API/Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.ContainerName }}:latest
+
+      - uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} deployment ${{ env.AppPrefix }}
+
+      - uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} service ${{ env.AppPrefix }}-svc
+
+      - uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} ingress ${{ env.AppPrefix }}-ingress
+
+      - uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} pod -l app=${{ env.AppPrefix }}
+
+      - uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: create -f ./LeoCloud/backend-leocloud-${{ env.CloudNameSpace }}-${{ env.AppPrefix }}.yaml

--- a/.github/workflows/Backend.yaml
+++ b/.github/workflows/Backend.yaml
@@ -1,34 +1,21 @@
-name: Backend(ClimbConnect) Docker (for LeoCloud)
-
-env:
-  ContainerName: climbconnectapi
-  CloudNameSpace: student-r-lehner
-  AppPrefix: climbconnectapi
+name: Backend(ClimbConnect) Deploy to VPS
 
 on:
   push:
     branches: ["main"]
     paths:
       - "backend/**"
+      - "docker-compose.yml"
 
 jobs:
-  docker:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -36,40 +23,21 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: ./backend/ClimbConnect.API
           file: ./backend/ClimbConnect.API/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.ContainerName }}:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/climbconnectapi:latest
 
-      - uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+      - name: Deploy on VPS via SSH
+        uses: appleboy/ssh-action@v1
         with:
-          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} deployment ${{ env.AppPrefix }}
-
-      - uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} service ${{ env.AppPrefix }}-svc
-
-      - uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} ingress ${{ env.AppPrefix }}-ingress
-
-      - uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: delete --ignore-not-found -n ${{ env.CloudNameSpace }} pod -l app=${{ env.AppPrefix }}
-
-      - uses: actions-hub/kubectl@master
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-        with:
-          args: create -f ./LeoCloud/backend-leocloud-${{ env.CloudNameSpace }}-${{ env.AppPrefix }}.yaml
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            cd /app/climbconnect
+            docker compose pull
+            docker compose up -d

--- a/LeoCloud/UpdateLeocloudBackend.cmd
+++ b/LeoCloud/UpdateLeocloudBackend.cmd
@@ -1,0 +1,15 @@
+@echo off
+set NameSpace=student-r-lehner
+set AppPrefix=climbconnectapi
+
+kubectl delete -n %NameSpace% deployment %AppPrefix%
+kubectl delete -n %NameSpace% service %AppPrefix%-svc
+kubectl delete -n %NameSpace% ingress %AppPrefix%-ingress
+kubectl delete -n %NameSpace% pod -l app=%AppPrefix%
+kubectl create -f ./backend-leocloud-%NameSpace%-%AppPrefix%-volumeClaim.yaml
+kubectl create -f ./backend-leocloud-%NameSpace%-%AppPrefix%.yaml
+
+pause
+
+:: Daten aus Volume kopieren:
+:: kubectl cp %NameSpace%/<pod-name>:/app/Data .

--- a/LeoCloud/backend-leocloud-student-r-lehner-climbconnectapi-volumeClaim.yaml
+++ b/LeoCloud/backend-leocloud-student-r-lehner-climbconnectapi-volumeClaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: climbconnectapi-database
+  namespace: student-r-lehner
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Mi

--- a/LeoCloud/backend-leocloud-student-r-lehner-climbconnectapi.yaml
+++ b/LeoCloud/backend-leocloud-student-r-lehner-climbconnectapi.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: climbconnectapi
-        image: DOCKERHUB_USERNAME/climbconnectapi:latest
+        image: robinlehner/climbconnectapi:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/LeoCloud/backend-leocloud-student-r-lehner-climbconnectapi.yaml
+++ b/LeoCloud/backend-leocloud-student-r-lehner-climbconnectapi.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: climbconnectapi
+  namespace: student-r-lehner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: climbconnectapi
+  template:
+    metadata:
+      labels:
+        app: climbconnectapi
+    spec:
+      containers:
+      - name: climbconnectapi
+        image: DOCKERHUB_USERNAME/climbconnectapi:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: ASPNETCORE_ENVIRONMENT
+          value: Production
+        - name: Keycloak__AuthServerUrl
+          value: "https://auth.cloud.htl-leonding.ac.at"
+        - name: Keycloak__Realm
+          value: "climbconnect"
+        volumeMounts:
+        - name: data
+          mountPath: /app/Data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: climbconnectapi-database
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: climbconnectapi-svc
+  namespace: student-r-lehner
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: climbconnectapi
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: climbconnectapi-ingress
+  namespace: student-r-lehner
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: r-lehner.cloud.htl-leonding.ac.at
+    http:
+      paths:
+      - path: /climbconnectapi(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: climbconnectapi-svc
+            port:
+              number: 80

--- a/backend/ClimbConnect.API/ClimbConnect.API.csproj
+++ b/backend/ClimbConnect.API/ClimbConnect.API.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-   
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Keycloak.AuthServices.Authentication" Version="2.5.3" />
+    <PackageReference Include="Keycloak.AuthServices.Authorization" Version="2.5.3" />
   </ItemGroup>
 
 </Project>

--- a/backend/ClimbConnect.API/Dockerfile
+++ b/backend/ClimbConnect.API/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER $APP_UID
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["ClimbConnect.API.csproj", "."]
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+USER root
+RUN mkdir -p /app/Data && chmod -R 777 /app/Data
+ENTRYPOINT ["dotnet", "ClimbConnect.API.dll"]

--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -1,25 +1,106 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.Sqlite;
+using Microsoft.OpenApi.Models;
 using ClimbConnect.API.Models;
 using ClimbConnect.API.Dtos;
+using Keycloak.AuthServices.Authentication;
+using Keycloak.AuthServices.Authorization;
+using Keycloak.AuthServices.Common;
 using Route = ClimbConnect.API.Models.Route;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Swagger
+// --------------------
+// SWAGGER
+// --------------------
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    var kc = builder.Configuration.GetKeycloakOptions<KeycloakAuthenticationOptions>()!;
 
-// EF Core InMemory
+    c.AddSecurityDefinition("oidc", new OpenApiSecurityScheme
+    {
+        Name             = "oauth2",
+        Type             = SecuritySchemeType.OpenIdConnect,
+        OpenIdConnectUrl = new Uri(kc.OpenIdConnectUrl!)
+    });
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oidc" }
+            },
+            Array.Empty<string>()
+        }
+    });
+
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "ClimbConnect API", Version = "v1" });
+});
+
+// --------------------
+// CORS
+// --------------------
+builder.Services.AddCors();
+
+// --------------------
+// KEYCLOAK AUTH
+// --------------------
+builder.Services.AddKeycloakWebApiAuthentication(builder.Configuration);
+builder.Services
+    .AddAuthorization()
+    .AddKeycloakAuthorization(builder.Configuration)
+    .AddAuthorizationBuilder()
+    .AddPolicy("Admin", b => b.RequireResourceRoles("admin"))
+    .AddPolicy("User",  b => b.RequireResourceRoles("user"));
+
+// --------------------
+// SQLITE
+// --------------------
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")!;
+var sqliteBuilder    = new SqliteConnectionStringBuilder(connectionString);
+sqliteBuilder.DataSource = Path.GetFullPath(
+    Path.Combine(
+        AppDomain.CurrentDomain.GetData("DataDirectory") as string
+            ?? AppDomain.CurrentDomain.BaseDirectory,
+        sqliteBuilder.DataSource
+    ));
+connectionString = sqliteBuilder.ToString();
+
 builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseInMemoryDatabase("ClimbConnectDb"));
+    options.UseSqlite(connectionString));
 
 var app = builder.Build();
 
-// Swagger UI
-app.UseSwagger();
-app.UseSwaggerUI();
+// --------------------
+// SWAGGER UI
+// --------------------
+app.UseSwagger(options =>
+{
+    options.PreSerializeFilters.Add((doc, request) =>
+    {
+        if (request.Host.Value!.Contains(".cloud.htl-leonding.ac.at"))
+        {
+            doc.Servers =
+            [
+                new OpenApiServer { Url = $"{request.Scheme}s://{request.Host.Value}/climbconnectapi" }
+            ];
+        }
+    });
+});
+app.UseSwaggerUI(options => options.OAuthClientId("climbconnect-ui"));
 
 app.UseHttpsRedirection();
+app.UseCors(b => b.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin());
+app.UseAuthentication();
+app.UseAuthorization();
+
+// DB-Schema anlegen (ohne Migrations)
+using (var scope = app.Services.CreateScope())
+{
+    scope.ServiceProvider.GetRequiredService<AppDbContext>().Database.EnsureCreated();
+}
 
 
 // --------------------
@@ -31,76 +112,21 @@ app.MapGet("/api/health", () =>
 
 
 // --------------------
-// WEATHER (Demo)
+// AREAS
 // --------------------
-app.MapGet("/weatherforecast", () =>
-{
-    var summaries = new[]
-    {
-        "Freezing","Bracing","Chilly","Cool","Mild",
-        "Warm","Balmy","Hot","Sweltering","Scorching"
-    };
-
-    var forecast = Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast(
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        )
-    ).ToArray();
-
-    return forecast;
-})
-.WithName("GetWeatherForecast");
-
-
-// --------------------
-// PINGS (DB-Test)
-// --------------------
-app.MapPost("/api/pings", async (AppDbContext db) =>
-{
-    var ping = new Ping();
-
-    db.Pings.Add(ping);
-    await db.SaveChangesAsync();
-
-    return Results.Created($"/api/pings/{ping.Id}", ping);
-})
-.WithName("CreatePing")
-.WithTags("Pings");
-
-
-// --------------------
-// AREAS (ISSUE #7)
-// --------------------
-
-// Alle Areas
 app.MapGet("/api/areas", async (AppDbContext db) =>
-{
-    var areas = await db.Areas
-        .OrderBy(a => a.Name)
-        .ToListAsync();
+    Results.Ok(await db.Areas.OrderBy(a => a.Name).ToListAsync()))
+   .WithName("GetAreas")
+   .WithTags("Areas");
 
-    return Results.Ok(areas);
-})
-.WithName("GetAreas")
-.WithTags("Areas");
-
-
-// Area nach ID
 app.MapGet("/api/areas/{id:int}", async (int id, AppDbContext db) =>
 {
     var area = await db.Areas.FindAsync(id);
-
-    return area is null
-        ? Results.NotFound()
-        : Results.Ok(area);
+    return area is null ? Results.NotFound() : Results.Ok(area);
 })
 .WithName("GetAreaById")
 .WithTags("Areas");
 
-
-// Area anlegen
 app.MapPost("/api/areas", async (AreaCreateDto dto, AppDbContext db) =>
 {
     if (string.IsNullOrWhiteSpace(dto.Name))
@@ -108,15 +134,12 @@ app.MapPost("/api/areas", async (AreaCreateDto dto, AppDbContext db) =>
 
     var area = new Area
     {
-        Name = dto.Name.Trim(),
-        Location = string.IsNullOrWhiteSpace(dto.Location)
-            ? null
-            : dto.Location.Trim()
+        Name     = dto.Name.Trim(),
+        Location = string.IsNullOrWhiteSpace(dto.Location) ? null : dto.Location.Trim()
     };
 
     db.Areas.Add(area);
     await db.SaveChangesAsync();
-
     return Results.Created($"/api/areas/{area.Id}", area);
 })
 .WithName("CreateArea")
@@ -124,10 +147,8 @@ app.MapPost("/api/areas", async (AreaCreateDto dto, AppDbContext db) =>
 
 
 // --------------------
-// ROUTES (ISSUE #8)
+// ROUTES
 // --------------------
-
-// Route anlegen
 app.MapPost("/api/routes", async (RouteCreateDto dto, AppDbContext db) =>
 {
     if (string.IsNullOrWhiteSpace(dto.Name))
@@ -135,28 +156,22 @@ app.MapPost("/api/routes", async (RouteCreateDto dto, AppDbContext db) =>
 
     var route = new Route
     {
-        Name = dto.Name.Trim(),
-        Grade = string.IsNullOrWhiteSpace(dto.Grade) ? null : dto.Grade.Trim(),
+        Name   = dto.Name.Trim(),
+        Grade  = string.IsNullOrWhiteSpace(dto.Grade)  ? null : dto.Grade.Trim(),
         Sector = string.IsNullOrWhiteSpace(dto.Sector) ? null : dto.Sector.Trim()
     };
 
     db.Routes.Add(route);
     await db.SaveChangesAsync();
-
     return Results.Created($"/api/routes/{route.Id}", route);
 })
 .WithName("CreateRoute")
 .WithTags("Routes");
 
-
-// Route Detail
 app.MapGet("/api/routes/{id:int}", async (int id, AppDbContext db) =>
 {
     var route = await db.Routes.FindAsync(id);
-
-    return route is null
-        ? Results.NotFound()
-        : Results.Ok(route);
+    return route is null ? Results.NotFound() : Results.Ok(route);
 })
 .WithName("GetRouteById")
 .WithTags("Routes");
@@ -170,23 +185,30 @@ app.Run();
 // --------------------
 public class AppDbContext : DbContext
 {
-    public AppDbContext(DbContextOptions<AppDbContext> options)
-        : base(options) { }
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
-    public DbSet<Ping> Pings => Set<Ping>();
-    public DbSet<Area> Areas => Set<Area>();
-    public DbSet<Route> Routes => Set<Route>();
+    public DbSet<Ping>            Pings            => Set<Ping>();
+    public DbSet<Area>            Areas            => Set<Area>();
+    public DbSet<Route>           Routes           => Set<Route>();
+    public DbSet<User>            Users            => Set<User>();
+    public DbSet<Progress>        Progresses       => Set<Progress>();
+    public DbSet<Appointment>     Appointments     => Set<Appointment>();
+    public DbSet<AppointmentUser> AppointmentUsers => Set<AppointmentUser>();
+    public DbSet<Comment>         Comments         => Set<Comment>();
+    public DbSet<Report>          Reports          => Set<Report>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AppointmentUser>()
+            .HasKey(au => new { au.AppointmentId, au.UserId });
+    }
 }
 
 
 // --------------------
 // RECORDS
 // --------------------
-public record WeatherForecast(
-    DateOnly Date,
-    int TemperatureC,
-    string? Summary)
+public record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
-    public int TemperatureF =>
-        32 + (int)(TemperatureC / 0.5556);
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 }

--- a/backend/ClimbConnect.API/appsettings.Development.json
+++ b/backend/ClimbConnect.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Keycloak": {
+    "AuthServerUrl": "http://localhost:8080"
   }
 }

--- a/backend/ClimbConnect.API/appsettings.json
+++ b/backend/ClimbConnect.API/appsettings.json
@@ -1,9 +1,19 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=Data/ClimbConnect.db;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Keycloak": {
+    "Realm": "climbconnect",
+    "AuthServerUrl": "https://auth.cloud.htl-leonding.ac.at",
+    "Resource": "climbconnect-api",
+    "VerifyTokenAudience": false,
+    "PublicClient": true
   },
   "AllowedHosts": "*"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  api:
+    build:
+      context: ./backend/ClimbConnect.API
+      dockerfile: Dockerfile
+    ports:
+      - "5004:8080"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__DefaultConnection=Data Source=Data/ClimbConnect.db;
+      - Keycloak__AuthServerUrl=http://keycloak:8080
+      - Keycloak__Realm=climbconnect
+      - Keycloak__Resource=climbconnect-api
+    volumes:
+      - climbconnect-data:/app/Data
+    depends_on:
+      keycloak:
+        condition: service_healthy
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.2
+    ports:
+      - "8080:8080"
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+    command: start-dev
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+
+volumes:
+  climbconnect-data:


### PR DESCRIPTION
## Summary
- Switch EF Core from InMemory to **SQLite** (persistent, `Data/ClimbConnect.db`)
- Add **Keycloak** authentication via `Keycloak.AuthServices` NuGet packages
- Add **Dockerfile** (multi-stage .NET 8 build)
- Add **docker-compose.yml** for local development (API + Keycloak container)
- Add **GitHub Actions** workflow: build → push to Docker Hub → deploy via kubectl
- Add **LeoCloud/** Kubernetes YAML (Deployment, Service, Ingress, PVC)
- Register all DbSets in `AppDbContext` + composite PK for `AppointmentUser`
- Add CORS, Swagger OIDC security definition, LeoCloud path prefix filter

## Still needed before first deploy
- [ ] `KUBE_CONFIG` GitHub Secret (from professor)
- [ ] LeoCloud namespace confirmation (`student-r-lehner`)
- [ ] Keycloak realm setup on `auth.cloud.htl-leonding.ac.at`

## Test plan
- [ ] `dotnet build` passes with 0 errors
- [ ] `docker compose up` starts API + Keycloak
- [ ] Swagger UI opens at `http://localhost:5004/swagger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)