### PR TITLE
feat: Sector-Entity, Grad-Konversion, alle Endpoints überarbeitet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# ClimbConnect – Claude Code Anweisungen
+
+## Mein Arbeitsstil
+
+- Bevor du eine Datei erstellst oder änderst, erkläre kurz:
+  - Was die Datei ist und was sie macht
+  - Warum du sie so strukturiert hast
+- Warte dann auf meine Bestätigung bevor du weitermachst
+- Nach jeder abgeschlossenen Datei erkläre den Code:
+  - Was macht jede Klasse / Methode / Funktion?
+  - Warum hast du es so gelöst und nicht anders?
+  - Was sollte ich als Entwickler darüber wissen?
+- Nach jedem abgeschlossenen Issue fasse zusammen:
+  - Was wurde implementiert?
+  - Welche Dateien wurden erstellt oder verändert?
+  - Was hat sich im Projekt dadurch verändert?
+  - Was ist der nächste logische Schritt?
+
+## GitHub – Nimm mich bei der Hand
+
+Ich bin kein erfahrener Entwickler. Wenn etwas auf GitHub erledigt werden
+muss, sag mir GENAU was ich tun soll. Zum Beispiel:
+
+- "Geh jetzt auf GitHub → Issues → New Issue und erstelle ein Issue mit Titel X"
+- "Geh zu Pull Requests und merge Branch X in main"
+- "Schließ Issue #72 – der ist jetzt erledigt"
+
+Wenn du einen Commit oder Push machst, sag mir danach explizit:
+- Welche Dateien du geändert hast
+- Mit welcher Commit-Message
+- Ob der Push erfolgreich war (mit GitHub-Link)
+
+Wenn ein Push fehlschlägt, erkläre mir Schritt für Schritt wie ich das behebe.
+
+## Workflow pro Feature
+
+1. Sag mir welches GitHub Issue wir gerade bearbeiten
+2. Erkläre kurz was wir implementieren und warum
+3. Implementiere Datei für Datei – warte auf meine Bestätigung
+4. Erkläre nach jeder Datei den Code verständlich
+5. Commit mit sinnvoller Message (z.B. "feat: Areas Endpoints (closes #67)")
+6. Push und zeig mir den GitHub-Link
+7. Fasse zusammen was sich im Projekt verändert hat
+8. Sag mir was der nächste Schritt ist
+
+## Projektziele & Features
+
+### Rollen (Keycloak)
+- **Admin** (nur wir): kann Gebiete, Sektoren und Routen anlegen,
+  bearbeiten und löschen
+- **User** (alle anderen): kann nur lesen, eigenen Fortschritt eintragen,
+  Kommentare schreiben, Termine erstellen und beitreten
+
+### Features im Überblick
+
+**Gebiete, Sektoren & Routen (nur Admin)**
+- Klettergebiete in OÖ verwalten (Area → Sektor → Route)
+- Routen haben: Name, Grad (franz. Skala intern), Stil, Länge, Beschreibung
+- Grad wird per API in franz., amerikanischer oder UIAA-Skala ausgegeben
+  je nach Benutzereinstellung
+
+**Fortschritt (User)**
+- Route eintragen: Status (Projekt/Rotpunkt/Flash/Onsight),
+  Begehungsart (Toprope/Vorstieg), Anzahl Versuche, Notiz
+- Subjektive Gradbewertung + kurzer Kommentar (fließt in Community-Grad ein)
+
+**Statistiken (User)**
+- Gradentwicklung über Zeit als Chart (Rotpunkt-Grad pro Monat)
+- Anzahl gekletterte Routen, offene Projekte, Lieblingsgebiet
+
+**Terminplaner (User)**
+- Termin erstellen: Gebiet, Datum, Uhrzeit, Beschreibung,
+  Mindest- und Maximalanzahl Teilnehmer
+- Beitreten / Austreten
+- Durchschnittsgrad der Teilnehmer sehen (in Benutzer-Skala)
+
+**Gebietsübersicht**
+- Direkt in der Liste: wie viele Leute heute dort sind und
+  wie viele vorhaben zu kommen (aus Terminplaner-Daten)
+
+**Kommentare & Bilder (User)**
+- Kommentar mit Foto zu Gebiet oder Route (informativ, kein Chat)
+- Kein Chat, kein Follow-System, keine Direktnachrichten
+
+**Safety Reports (User)**
+- Report zu einer Route: Beschreibung, Schweregrad (Low/Medium/High), Foto
+
+**Öffentliche Profile**
+- Andere User können letzte Begehungen eines Profils sehen (Gebiet + Grad)
+
+## Projekt
+
+- Diplomarbeit HTL Leonding
+- Referenz-Vorlage: https://github.com/aitenbichler/DemoSyp
+- Repo: https://github.com/LehnerRobin/ClimbConnect
+
+## Pflichtlektüre beim Start
+
+Lies diese Dateien bevor du mit der Implementierung beginnst:
+- `docs/pitch.md` – Projektbeschreibung und Ziel der App
+- `docs/meilensteine.md` – Was der User bei jedem Meilenstein können soll
+- `docs/er-diagram.md` – Datenmodell mit allen Entities und Beziehungen
+
+## Stack
+
+- Backend: .NET 8 Minimal API, C#, EF Core, PostgreSQL
+- Auth: Keycloak (Rollen: Admin, User)
+- Frontend: Angular (anderer Kollege zuständig)
+- CI/CD: GitHub Actions
+- Grades: intern französische Skala, Konversion zu UIAA und Amerikanisch
+
+## Coding-Stil
+
+- Kommentare auf Deutsch
+- XML-Dokumentation (///) bei allen public Methoden und Klassen
+- Konsistente Benennung nach bestehendem Code
+- Keine unnötigen Abhängigkeiten
+- Nach jeder Methode / Klasse kurz erklären was sie tut
+
+## Offene Issues (Backend)
+
+- #67 Endpunkte Areas (nur Admin: POST/PUT/DELETE, alle: GET)
+- #68 Endpunkte Sektoren
+- #69 Endpunkte Routes
+- #70 Endpunkte Progress
+- #71 Endpunkte Appointments
+- #72 ER-Diagramm ✅
+- #73 Models & Tabellen definieren
+- #74 Beispiel-Testdaten (Seed)
+- #75 Keycloak Integration & Rollen
+- #76 Grad-Konversion (franz./UIAA/amerikanisch)

--- a/backend/ClimbConnect.API/Dtos/AppointmentCreateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/AppointmentCreateDto.cs
@@ -1,0 +1,11 @@
+namespace ClimbConnect.API.Dtos;
+
+public record AppointmentCreateDto(
+    int CreatedByUserId,
+    string Title,
+    DateTime Date,
+    string? MeetingPoint,
+    string? Description,
+    int? MinParticipants,
+    int? MaxParticipants
+);

--- a/backend/ClimbConnect.API/Dtos/AppointmentSubscribeDto.cs
+++ b/backend/ClimbConnect.API/Dtos/AppointmentSubscribeDto.cs
@@ -1,0 +1,3 @@
+namespace ClimbConnect.API.Dtos;
+
+public record AppointmentSubscribeDto(int UserId, string? Comment);

--- a/backend/ClimbConnect.API/Dtos/AreaUpdateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/AreaUpdateDto.cs
@@ -1,0 +1,3 @@
+namespace ClimbConnect.API.Dtos;
+
+public record AreaUpdateDto(string Name, string? Location, string? Description);

--- a/backend/ClimbConnect.API/Dtos/ProgressCreateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/ProgressCreateDto.cs
@@ -1,0 +1,13 @@
+namespace ClimbConnect.API.Dtos;
+
+public record ProgressCreateDto(
+    int UserId,
+    int RouteId,
+    string Status,
+    string ClimbingStyle,
+    int Attempts,
+    string? Notes,
+    DateOnly Date,
+    string? SubjectiveGrade,
+    string? SubjectiveGradeComment
+);

--- a/backend/ClimbConnect.API/Dtos/ProgressUpdateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/ProgressUpdateDto.cs
@@ -1,0 +1,11 @@
+namespace ClimbConnect.API.Dtos;
+
+public record ProgressUpdateDto(
+    string Status,
+    string ClimbingStyle,
+    int Attempts,
+    string? Notes,
+    DateOnly Date,
+    string? SubjectiveGrade,
+    string? SubjectiveGradeComment
+);

--- a/backend/ClimbConnect.API/Dtos/ReportCreateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/ReportCreateDto.cs
@@ -5,5 +5,6 @@ public record ReportCreateDto(
     int? AreaId,
     int? RouteId,
     string Text,
-    string? PhotoUrl
+    string? PhotoUrl,
+    string Severity
 );

--- a/backend/ClimbConnect.API/Dtos/RouteUpdateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/RouteUpdateDto.cs
@@ -1,6 +1,6 @@
 namespace ClimbConnect.API.Dtos;
 
-public record RouteCreateDto(
+public record RouteUpdateDto(
     string Name,
     string? Grade,
     int? LengthMeters,

--- a/backend/ClimbConnect.API/Dtos/SectorCreateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/SectorCreateDto.cs
@@ -1,0 +1,3 @@
+namespace ClimbConnect.API.Dtos;
+
+public record SectorCreateDto(string Name, string? Description);

--- a/backend/ClimbConnect.API/Dtos/SectorUpdateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/SectorUpdateDto.cs
@@ -1,0 +1,3 @@
+namespace ClimbConnect.API.Dtos;
+
+public record SectorUpdateDto(string Name, string? Description);

--- a/backend/ClimbConnect.API/Models/Appointment.cs
+++ b/backend/ClimbConnect.API/Models/Appointment.cs
@@ -1,16 +1,29 @@
 namespace ClimbConnect.API.Models;
 
+/// <summary>
+/// Klettertermin in einem Gebiet. User können beitreten (subscribe).
+/// </summary>
 public class Appointment
 {
     public int Id { get; set; }
+
     public int AreaId { get; set; }
     public int CreatedByUserId { get; set; }
+
     public string Title { get; set; } = string.Empty;
     public DateTime Date { get; set; }
     public string? MeetingPoint { get; set; }
     public string? Description { get; set; }
+
+    /// <summary>Mindestanzahl Teilnehmer (optional).</summary>
+    public int? MinParticipants { get; set; }
+
+    /// <summary>Maximalanzahl Teilnehmer (optional). Subscribe wird ab diesem Limit gesperrt.</summary>
+    public int? MaxParticipants { get; set; }
+
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
+    // Navigation
     public Area Area { get; set; } = null!;
     public User CreatedBy { get; set; } = null!;
     public ICollection<AppointmentUser> AppointmentUsers { get; set; } = [];

--- a/backend/ClimbConnect.API/Models/Area.cs
+++ b/backend/ClimbConnect.API/Models/Area.cs
@@ -1,14 +1,21 @@
 namespace ClimbConnect.API.Models;
 
+/// <summary>
+/// Repräsentiert ein Klettergebiet in OÖ (oberste Ebene: Area → Sector → Route).
+/// </summary>
 public class Area
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
+
+    /// <summary>Ort des Gebiets, z.B. "Hinterstoder", "Bad Ischl".</summary>
     public string? Location { get; set; }
+
     public string? Description { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
-    public ICollection<Route> Routes { get; set; } = [];
+    // Navigation
+    public ICollection<Sector> Sectors { get; set; } = [];
     public ICollection<Appointment> Appointments { get; set; } = [];
     public ICollection<Comment> Comments { get; set; } = [];
     public ICollection<Report> Reports { get; set; } = [];

--- a/backend/ClimbConnect.API/Models/Progress.cs
+++ b/backend/ClimbConnect.API/Models/Progress.cs
@@ -1,16 +1,44 @@
 namespace ClimbConnect.API.Models;
 
+/// <summary>
+/// Speichert den Fortschritt eines Users an einer Route.
+/// Status: Projekt, Rotpunkt, Flash oder Onsight.
+/// </summary>
 public class Progress
 {
     public int Id { get; set; }
+
     public int UserId { get; set; }
     public int RouteId { get; set; }
-    public string Status { get; set; } = "Attempted";   // "Attempted" | "Completed" | "Flashed" | "Onsight"
+
+    /// <summary>
+    /// Begehungsstatus: "Projekt", "Rotpunkt", "Flash" oder "Onsight".
+    /// </summary>
+    public string Status { get; set; } = "Projekt";
+
+    /// <summary>
+    /// Begehungsart: "Toprope" oder "Vorstieg".
+    /// </summary>
+    public string ClimbingStyle { get; set; } = "Vorstieg";
+
+    /// <summary>Anzahl der Versuche an dieser Route.</summary>
     public int Attempts { get; set; } = 0;
+
     public string? Notes { get; set; }
     public DateOnly Date { get; set; }
+
+    /// <summary>
+    /// Subjektiver Grad des Users in der französischen Skala, z.B. "6b".
+    /// Fließt in den Community-Grad der Route ein.
+    /// </summary>
+    public string? SubjectiveGrade { get; set; }
+
+    /// <summary>Kurzer Kommentar zur subjektiven Gradbewertung.</summary>
+    public string? SubjectiveGradeComment { get; set; }
+
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
+    // Navigation
     public User User { get; set; } = null!;
     public Route Route { get; set; } = null!;
 }

--- a/backend/ClimbConnect.API/Models/Report.cs
+++ b/backend/ClimbConnect.API/Models/Report.cs
@@ -1,16 +1,29 @@
 namespace ClimbConnect.API.Models;
 
+/// <summary>
+/// Sicherheitsmeldung zu einem Gebiet oder einer Route.
+/// Status wird vom Admin verwaltet, Severity wird vom User gesetzt.
+/// </summary>
 public class Report
 {
     public int Id { get; set; }
+
     public int UserId { get; set; }
     public int? AreaId { get; set; }
     public int? RouteId { get; set; }
+
     public string Text { get; set; } = string.Empty;
     public string? PhotoUrl { get; set; }
-    public string Status { get; set; } = "Open";   // "Open" | "Resolved"
+
+    /// <summary>Schweregrad: "Low", "Medium" oder "High".</summary>
+    public string Severity { get; set; } = "Low";
+
+    /// <summary>Bearbeitungsstatus durch Admin: "Open" oder "Resolved".</summary>
+    public string Status { get; set; } = "Open";
+
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
+    // Navigation
     public User User { get; set; } = null!;
     public Area? Area { get; set; }
     public Route? Route { get; set; }

--- a/backend/ClimbConnect.API/Models/Route.cs
+++ b/backend/ClimbConnect.API/Models/Route.cs
@@ -1,18 +1,31 @@
 namespace ClimbConnect.API.Models;
 
+/// <summary>
+/// Repräsentiert eine Kletterroute innerhalb eines Sektors (Area → Sector → Route).
+/// Der Grad wird intern immer in der französischen Skala gespeichert.
+/// </summary>
 public class Route
 {
     public int Id { get; set; }
-    public int AreaId { get; set; }
+
+    /// <summary>Fremdschlüssel zum übergeordneten Sektor.</summary>
+    public int SectorId { get; set; }
+
     public string Name { get; set; } = string.Empty;
-    public string? Grade { get; set; }        // UIAA, z.B. "6b", "7a+"
-    public string? Sector { get; set; }
+
+    /// <summary>Grad in der französischen Skala, z.B. "6b", "7a+".</summary>
+    public string? Grade { get; set; }
+
     public int? LengthMeters { get; set; }
-    public string? Style { get; set; }        // z.B. "Sport", "Trad"
+
+    /// <summary>Klettersti, z.B. "Sport", "Trad".</summary>
+    public string? Style { get; set; }
+
     public string? Description { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
-    public Area Area { get; set; } = null!;
+    // Navigation
+    public Sector Sector { get; set; } = null!;
     public ICollection<Progress> Progresses { get; set; } = [];
     public ICollection<Comment> Comments { get; set; } = [];
     public ICollection<Report> Reports { get; set; } = [];

--- a/backend/ClimbConnect.API/Models/Sector.cs
+++ b/backend/ClimbConnect.API/Models/Sector.cs
@@ -1,0 +1,20 @@
+namespace ClimbConnect.API.Models;
+
+/// <summary>
+/// Repräsentiert einen Sektor innerhalb eines Klettergebiets (Area → Sector → Route).
+/// </summary>
+public class Sector
+{
+    public int Id { get; set; }
+
+    /// <summary>Fremdschlüssel zum übergeordneten Gebiet.</summary>
+    public int AreaId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    // Navigation
+    public Area Area { get; set; } = null!;
+    public ICollection<Route> Routes { get; set; } = [];
+}

--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.OpenApi.Models;
 using ClimbConnect.API.Models;
 using ClimbConnect.API.Dtos;
+using ClimbConnect.API.Services;
 using Keycloak.AuthServices.Authentication;
 using Keycloak.AuthServices.Authorization;
 using Keycloak.AuthServices.Common;
@@ -24,7 +25,6 @@ builder.Services.AddSwaggerGen(c =>
         Type             = SecuritySchemeType.OpenIdConnect,
         OpenIdConnectUrl = new Uri(kc.OpenIdConnectUrl!)
     });
-
     c.AddSecurityRequirement(new OpenApiSecurityRequirement
     {
         {
@@ -35,7 +35,6 @@ builder.Services.AddSwaggerGen(c =>
             Array.Empty<string>()
         }
     });
-
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "ClimbConnect API", Version = "v1" });
 });
 
@@ -112,7 +111,7 @@ app.MapGet("/api/health", () =>
 
 
 // --------------------
-// AREAS
+// AREAS (Admin: POST/PUT/DELETE, alle: GET)
 // --------------------
 app.MapGet("/api/areas", async (AppDbContext db) =>
     Results.Ok(await db.Areas.OrderBy(a => a.Name).ToListAsync()))
@@ -121,7 +120,9 @@ app.MapGet("/api/areas", async (AppDbContext db) =>
 
 app.MapGet("/api/areas/{id:int}", async (int id, AppDbContext db) =>
 {
-    var area = await db.Areas.FindAsync(id);
+    var area = await db.Areas
+        .Include(a => a.Sectors)
+        .FirstOrDefaultAsync(a => a.Id == id);
     return area is null ? Results.NotFound() : Results.Ok(area);
 })
 .WithName("GetAreaById")
@@ -137,7 +138,6 @@ app.MapPost("/api/areas", async (AreaCreateDto dto, AppDbContext db) =>
         Name     = dto.Name.Trim(),
         Location = string.IsNullOrWhiteSpace(dto.Location) ? null : dto.Location.Trim()
     };
-
     db.Areas.Add(area);
     await db.SaveChangesAsync();
     return Results.Created($"/api/areas/{area.Id}", area);
@@ -145,22 +145,169 @@ app.MapPost("/api/areas", async (AreaCreateDto dto, AppDbContext db) =>
 .WithName("CreateArea")
 .WithTags("Areas");
 
+app.MapPut("/api/areas/{id:int}", async (int id, AreaUpdateDto dto, AppDbContext db) =>
+{
+    var area = await db.Areas.FindAsync(id);
+    if (area is null) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(dto.Name))
+        return Results.BadRequest(new { error = "Name is required" });
+
+    area.Name        = dto.Name.Trim();
+    area.Location    = string.IsNullOrWhiteSpace(dto.Location)    ? null : dto.Location.Trim();
+    area.Description = string.IsNullOrWhiteSpace(dto.Description) ? null : dto.Description.Trim();
+
+    await db.SaveChangesAsync();
+    return Results.Ok(area);
+})
+.WithName("UpdateArea")
+.WithTags("Areas");
+
+app.MapDelete("/api/areas/{id:int}", async (int id, AppDbContext db) =>
+{
+    var area = await db.Areas.FindAsync(id);
+    if (area is null) return Results.NotFound();
+    db.Areas.Remove(area);
+    await db.SaveChangesAsync();
+    return Results.NoContent();
+})
+.WithName("DeleteArea")
+.WithTags("Areas");
+
 
 // --------------------
-// ROUTES
+// SECTORS (Admin: POST/PUT/DELETE, alle: GET)
 // --------------------
-app.MapPost("/api/routes", async (RouteCreateDto dto, AppDbContext db) =>
+app.MapGet("/api/areas/{id:int}/sectors", async (int id, AppDbContext db) =>
 {
+    if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
+
+    var sectors = await db.Sectors
+        .Where(s => s.AreaId == id)
+        .OrderBy(s => s.Name)
+        .ToListAsync();
+
+    return Results.Ok(sectors);
+})
+.WithName("GetSectorsByArea")
+.WithTags("Sectors");
+
+app.MapGet("/api/sectors/{id:int}", async (int id, AppDbContext db) =>
+{
+    var sector = await db.Sectors
+        .Include(s => s.Routes)
+        .FirstOrDefaultAsync(s => s.Id == id);
+    return sector is null ? Results.NotFound() : Results.Ok(sector);
+})
+.WithName("GetSectorById")
+.WithTags("Sectors");
+
+app.MapPost("/api/areas/{id:int}/sectors", async (int id, SectorCreateDto dto, AppDbContext db) =>
+{
+    if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(dto.Name))
+        return Results.BadRequest(new { error = "Name is required" });
+
+    var sector = new Sector
+    {
+        AreaId      = id,
+        Name        = dto.Name.Trim(),
+        Description = string.IsNullOrWhiteSpace(dto.Description) ? null : dto.Description.Trim()
+    };
+    db.Sectors.Add(sector);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/sectors/{sector.Id}", sector);
+})
+.WithName("CreateSector")
+.WithTags("Sectors");
+
+app.MapPut("/api/sectors/{id:int}", async (int id, SectorUpdateDto dto, AppDbContext db) =>
+{
+    var sector = await db.Sectors.FindAsync(id);
+    if (sector is null) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(dto.Name))
+        return Results.BadRequest(new { error = "Name is required" });
+
+    sector.Name        = dto.Name.Trim();
+    sector.Description = string.IsNullOrWhiteSpace(dto.Description) ? null : dto.Description.Trim();
+
+    await db.SaveChangesAsync();
+    return Results.Ok(sector);
+})
+.WithName("UpdateSector")
+.WithTags("Sectors");
+
+app.MapDelete("/api/sectors/{id:int}", async (int id, AppDbContext db) =>
+{
+    var sector = await db.Sectors.FindAsync(id);
+    if (sector is null) return Results.NotFound();
+    db.Sectors.Remove(sector);
+    await db.SaveChangesAsync();
+    return Results.NoContent();
+})
+.WithName("DeleteSector")
+.WithTags("Sectors");
+
+
+// --------------------
+// ROUTES (Admin: POST/PUT/DELETE, alle: GET)
+// --------------------
+app.MapGet("/api/sectors/{id:int}/routes", async (int id, string? scale, AppDbContext db) =>
+{
+    if (!await db.Sectors.AnyAsync(s => s.Id == id)) return Results.NotFound();
+
+    var routes = await db.Routes
+        .Where(r => r.SectorId == id)
+        .OrderBy(r => r.Name)
+        .ToListAsync();
+
+    // Grad in gewünschter Skala ausgeben (Standard: französisch)
+    var result = routes.Select(r => new
+    {
+        r.Id, r.SectorId, r.Name,
+        Grade       = GradeConversionService.Convert(r.Grade, scale ?? "french"),
+        r.LengthMeters, r.Style, r.Description, r.CreatedAtUtc
+    });
+
+    return Results.Ok(result);
+})
+.WithName("GetRoutesBySector")
+.WithTags("Routes");
+
+app.MapGet("/api/routes/{id:int}", async (int id, string? scale, AppDbContext db) =>
+{
+    var route = await db.Routes
+        .Include(r => r.Sector)
+        .FirstOrDefaultAsync(r => r.Id == id);
+    if (route is null) return Results.NotFound();
+
+    var result = new
+    {
+        route.Id, route.SectorId,
+        SectorName  = route.Sector.Name,
+        route.Name,
+        Grade       = GradeConversionService.Convert(route.Grade, scale ?? "french"),
+        route.LengthMeters, route.Style, route.Description, route.CreatedAtUtc
+    };
+    return Results.Ok(result);
+})
+.WithName("GetRouteById")
+.WithTags("Routes");
+
+app.MapPost("/api/sectors/{id:int}/routes", async (int id, RouteCreateDto dto, AppDbContext db) =>
+{
+    if (!await db.Sectors.AnyAsync(s => s.Id == id)) return Results.NotFound();
     if (string.IsNullOrWhiteSpace(dto.Name))
         return Results.BadRequest(new { error = "Name is required" });
 
     var route = new Route
     {
-        Name   = dto.Name.Trim(),
-        Grade  = string.IsNullOrWhiteSpace(dto.Grade)  ? null : dto.Grade.Trim(),
-        Sector = string.IsNullOrWhiteSpace(dto.Sector) ? null : dto.Sector.Trim()
+        SectorId    = id,
+        Name        = dto.Name.Trim(),
+        Grade       = string.IsNullOrWhiteSpace(dto.Grade)       ? null : dto.Grade.Trim().ToLower(),
+        LengthMeters = dto.LengthMeters,
+        Style       = string.IsNullOrWhiteSpace(dto.Style)       ? null : dto.Style.Trim(),
+        Description = string.IsNullOrWhiteSpace(dto.Description) ? null : dto.Description.Trim()
     };
-
     db.Routes.Add(route);
     await db.SaveChangesAsync();
     return Results.Created($"/api/routes/{route.Id}", route);
@@ -168,13 +315,330 @@ app.MapPost("/api/routes", async (RouteCreateDto dto, AppDbContext db) =>
 .WithName("CreateRoute")
 .WithTags("Routes");
 
-app.MapGet("/api/routes/{id:int}", async (int id, AppDbContext db) =>
+app.MapPut("/api/routes/{id:int}", async (int id, RouteUpdateDto dto, AppDbContext db) =>
 {
     var route = await db.Routes.FindAsync(id);
-    return route is null ? Results.NotFound() : Results.Ok(route);
+    if (route is null) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(dto.Name))
+        return Results.BadRequest(new { error = "Name is required" });
+
+    route.Name        = dto.Name.Trim();
+    route.Grade       = string.IsNullOrWhiteSpace(dto.Grade)       ? null : dto.Grade.Trim().ToLower();
+    route.LengthMeters = dto.LengthMeters;
+    route.Style       = string.IsNullOrWhiteSpace(dto.Style)       ? null : dto.Style.Trim();
+    route.Description = string.IsNullOrWhiteSpace(dto.Description) ? null : dto.Description.Trim();
+
+    await db.SaveChangesAsync();
+    return Results.Ok(route);
 })
-.WithName("GetRouteById")
+.WithName("UpdateRoute")
 .WithTags("Routes");
+
+app.MapDelete("/api/routes/{id:int}", async (int id, AppDbContext db) =>
+{
+    var route = await db.Routes.FindAsync(id);
+    if (route is null) return Results.NotFound();
+    db.Routes.Remove(route);
+    await db.SaveChangesAsync();
+    return Results.NoContent();
+})
+.WithName("DeleteRoute")
+.WithTags("Routes");
+
+
+// --------------------
+// PROGRESS
+// --------------------
+app.MapGet("/api/progress/me", async (int userId, AppDbContext db) =>
+{
+    var entries = await db.Progresses
+        .Where(p => p.UserId == userId)
+        .Include(p => p.Route)
+        .OrderByDescending(p => p.Date)
+        .ToListAsync();
+    return Results.Ok(entries);
+})
+.WithName("GetMyProgress")
+.WithTags("Progress");
+
+app.MapPost("/api/progress", async (ProgressCreateDto dto, AppDbContext db) =>
+{
+    var validStatuses = new[] { "Projekt", "Rotpunkt", "Flash", "Onsight" };
+    var validStyles   = new[] { "Toprope", "Vorstieg" };
+
+    if (!validStatuses.Contains(dto.Status))
+        return Results.BadRequest(new { error = $"Status muss einer von: {string.Join(", ", validStatuses)} sein" });
+    if (!validStyles.Contains(dto.ClimbingStyle))
+        return Results.BadRequest(new { error = $"ClimbingStyle muss einer von: {string.Join(", ", validStyles)} sein" });
+    if (!await db.Users.AnyAsync(u => u.Id == dto.UserId))
+        return Results.BadRequest(new { error = "User nicht gefunden" });
+    if (!await db.Routes.AnyAsync(r => r.Id == dto.RouteId))
+        return Results.BadRequest(new { error = "Route nicht gefunden" });
+
+    var progress = new Progress
+    {
+        UserId                 = dto.UserId,
+        RouteId                = dto.RouteId,
+        Status                 = dto.Status,
+        ClimbingStyle          = dto.ClimbingStyle,
+        Attempts               = dto.Attempts,
+        Notes                  = string.IsNullOrWhiteSpace(dto.Notes) ? null : dto.Notes.Trim(),
+        Date                   = dto.Date,
+        SubjectiveGrade        = string.IsNullOrWhiteSpace(dto.SubjectiveGrade) ? null : dto.SubjectiveGrade.Trim().ToLower(),
+        SubjectiveGradeComment = string.IsNullOrWhiteSpace(dto.SubjectiveGradeComment) ? null : dto.SubjectiveGradeComment.Trim()
+    };
+    db.Progresses.Add(progress);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/progress/{progress.Id}", progress);
+})
+.WithName("CreateProgress")
+.WithTags("Progress");
+
+app.MapPut("/api/progress/{id:int}", async (int id, ProgressUpdateDto dto, AppDbContext db) =>
+{
+    var progress = await db.Progresses.FindAsync(id);
+    if (progress is null) return Results.NotFound();
+
+    var validStatuses = new[] { "Projekt", "Rotpunkt", "Flash", "Onsight" };
+    var validStyles   = new[] { "Toprope", "Vorstieg" };
+
+    if (!validStatuses.Contains(dto.Status))
+        return Results.BadRequest(new { error = $"Status muss einer von: {string.Join(", ", validStatuses)} sein" });
+    if (!validStyles.Contains(dto.ClimbingStyle))
+        return Results.BadRequest(new { error = $"ClimbingStyle muss einer von: {string.Join(", ", validStyles)} sein" });
+
+    progress.Status                 = dto.Status;
+    progress.ClimbingStyle          = dto.ClimbingStyle;
+    progress.Attempts               = dto.Attempts;
+    progress.Notes                  = string.IsNullOrWhiteSpace(dto.Notes) ? null : dto.Notes.Trim();
+    progress.Date                   = dto.Date;
+    progress.SubjectiveGrade        = string.IsNullOrWhiteSpace(dto.SubjectiveGrade) ? null : dto.SubjectiveGrade.Trim().ToLower();
+    progress.SubjectiveGradeComment = string.IsNullOrWhiteSpace(dto.SubjectiveGradeComment) ? null : dto.SubjectiveGradeComment.Trim();
+
+    await db.SaveChangesAsync();
+    return Results.Ok(progress);
+})
+.WithName("UpdateProgress")
+.WithTags("Progress");
+
+app.MapDelete("/api/progress/{id:int}", async (int id, AppDbContext db) =>
+{
+    var progress = await db.Progresses.FindAsync(id);
+    if (progress is null) return Results.NotFound();
+    db.Progresses.Remove(progress);
+    await db.SaveChangesAsync();
+    return Results.NoContent();
+})
+.WithName("DeleteProgress")
+.WithTags("Progress");
+
+
+// --------------------
+// APPOINTMENTS
+// --------------------
+app.MapGet("/api/areas/{id:int}/appointments", async (int id, AppDbContext db) =>
+{
+    if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
+
+    var appointments = await db.Appointments
+        .Where(a => a.AreaId == id)
+        .Include(a => a.AppointmentUsers)
+        .OrderBy(a => a.Date)
+        .ToListAsync();
+    return Results.Ok(appointments);
+})
+.WithName("GetAppointmentsByArea")
+.WithTags("Appointments");
+
+app.MapPost("/api/areas/{id:int}/appointments", async (int id, AppointmentCreateDto dto, AppDbContext db) =>
+{
+    if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(dto.Title))
+        return Results.BadRequest(new { error = "Title is required" });
+    if (!await db.Users.AnyAsync(u => u.Id == dto.CreatedByUserId))
+        return Results.BadRequest(new { error = "User nicht gefunden" });
+
+    var appointment = new Appointment
+    {
+        AreaId          = id,
+        CreatedByUserId = dto.CreatedByUserId,
+        Title           = dto.Title.Trim(),
+        Date            = dto.Date,
+        MeetingPoint    = string.IsNullOrWhiteSpace(dto.MeetingPoint)  ? null : dto.MeetingPoint.Trim(),
+        Description     = string.IsNullOrWhiteSpace(dto.Description)   ? null : dto.Description.Trim(),
+        MinParticipants = dto.MinParticipants,
+        MaxParticipants = dto.MaxParticipants
+    };
+    db.Appointments.Add(appointment);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/appointments/{appointment.Id}", appointment);
+})
+.WithName("CreateAppointment")
+.WithTags("Appointments");
+
+app.MapPost("/api/appointments/{id:int}/subscribe", async (int id, AppointmentSubscribeDto dto, AppDbContext db) =>
+{
+    var appointment = await db.Appointments
+        .Include(a => a.AppointmentUsers)
+        .FirstOrDefaultAsync(a => a.Id == id);
+    if (appointment is null) return Results.NotFound();
+    if (!await db.Users.AnyAsync(u => u.Id == dto.UserId))
+        return Results.BadRequest(new { error = "User nicht gefunden" });
+
+    if (appointment.AppointmentUsers.Any(au => au.UserId == dto.UserId))
+        return Results.Conflict(new { error = "Bereits angemeldet" });
+
+    if (appointment.MaxParticipants.HasValue &&
+        appointment.AppointmentUsers.Count >= appointment.MaxParticipants.Value)
+        return Results.Conflict(new { error = "Maximale Teilnehmerzahl erreicht" });
+
+    var subscription = new AppointmentUser
+    {
+        AppointmentId = id,
+        UserId        = dto.UserId,
+        Comment       = string.IsNullOrWhiteSpace(dto.Comment) ? null : dto.Comment.Trim()
+    };
+    db.AppointmentUsers.Add(subscription);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/appointments/{id}/subscribe", subscription);
+})
+.WithName("SubscribeToAppointment")
+.WithTags("Appointments");
+
+app.MapDelete("/api/appointments/{id:int}/subscribe", async (int id, int userId, AppDbContext db) =>
+{
+    var subscription = await db.AppointmentUsers
+        .FirstOrDefaultAsync(au => au.AppointmentId == id && au.UserId == userId);
+    if (subscription is null) return Results.NotFound();
+    db.AppointmentUsers.Remove(subscription);
+    await db.SaveChangesAsync();
+    return Results.NoContent();
+})
+.WithName("UnsubscribeFromAppointment")
+.WithTags("Appointments");
+
+
+// --------------------
+// COMMENTS
+// --------------------
+app.MapGet("/api/areas/{id:int}/comments", async (int id, AppDbContext db) =>
+{
+    if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
+    var comments = await db.Comments
+        .Where(c => c.AreaId == id)
+        .Include(c => c.User)
+        .OrderByDescending(c => c.CreatedAtUtc)
+        .ToListAsync();
+    return Results.Ok(comments);
+})
+.WithName("GetCommentsByArea")
+.WithTags("Comments");
+
+app.MapPost("/api/areas/{id:int}/comments", async (int id, CommentCreateDto dto, AppDbContext db) =>
+{
+    if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(dto.Text))
+        return Results.BadRequest(new { error = "Text is required" });
+    if (!await db.Users.AnyAsync(u => u.Id == dto.UserId))
+        return Results.BadRequest(new { error = "User nicht gefunden" });
+
+    var comment = new Comment { UserId = dto.UserId, AreaId = id, Text = dto.Text.Trim() };
+    db.Comments.Add(comment);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/areas/{id}/comments", comment);
+})
+.WithName("CreateCommentForArea")
+.WithTags("Comments");
+
+app.MapGet("/api/routes/{id:int}/comments", async (int id, AppDbContext db) =>
+{
+    if (!await db.Routes.AnyAsync(r => r.Id == id)) return Results.NotFound();
+    var comments = await db.Comments
+        .Where(c => c.RouteId == id)
+        .Include(c => c.User)
+        .OrderByDescending(c => c.CreatedAtUtc)
+        .ToListAsync();
+    return Results.Ok(comments);
+})
+.WithName("GetCommentsByRoute")
+.WithTags("Comments");
+
+app.MapPost("/api/routes/{id:int}/comments", async (int id, CommentCreateDto dto, AppDbContext db) =>
+{
+    if (!await db.Routes.AnyAsync(r => r.Id == id)) return Results.NotFound();
+    if (string.IsNullOrWhiteSpace(dto.Text))
+        return Results.BadRequest(new { error = "Text is required" });
+    if (!await db.Users.AnyAsync(u => u.Id == dto.UserId))
+        return Results.BadRequest(new { error = "User nicht gefunden" });
+
+    var comment = new Comment { UserId = dto.UserId, RouteId = id, Text = dto.Text.Trim() };
+    db.Comments.Add(comment);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/routes/{id}/comments", comment);
+})
+.WithName("CreateCommentForRoute")
+.WithTags("Comments");
+
+
+// --------------------
+// REPORTS
+// --------------------
+app.MapPost("/api/reports", async (ReportCreateDto dto, AppDbContext db) =>
+{
+    var validSeverities = new[] { "Low", "Medium", "High" };
+    if (!validSeverities.Contains(dto.Severity))
+        return Results.BadRequest(new { error = "Severity muss Low, Medium oder High sein" });
+    if (string.IsNullOrWhiteSpace(dto.Text))
+        return Results.BadRequest(new { error = "Text is required" });
+    if (dto.AreaId is null && dto.RouteId is null)
+        return Results.BadRequest(new { error = "AreaId oder RouteId muss angegeben werden" });
+    if (!await db.Users.AnyAsync(u => u.Id == dto.UserId))
+        return Results.BadRequest(new { error = "User nicht gefunden" });
+    if (dto.AreaId is not null && !await db.Areas.AnyAsync(a => a.Id == dto.AreaId))
+        return Results.BadRequest(new { error = "Area nicht gefunden" });
+    if (dto.RouteId is not null && !await db.Routes.AnyAsync(r => r.Id == dto.RouteId))
+        return Results.BadRequest(new { error = "Route nicht gefunden" });
+
+    var report = new Report
+    {
+        UserId   = dto.UserId,
+        AreaId   = dto.AreaId,
+        RouteId  = dto.RouteId,
+        Text     = dto.Text.Trim(),
+        PhotoUrl = string.IsNullOrWhiteSpace(dto.PhotoUrl) ? null : dto.PhotoUrl.Trim(),
+        Severity = dto.Severity,
+        Status   = "Open"
+    };
+    db.Reports.Add(report);
+    await db.SaveChangesAsync();
+    return Results.Created($"/api/reports/{report.Id}", report);
+})
+.WithName("CreateReport")
+.WithTags("Reports");
+
+app.MapGet("/api/reports", async (AppDbContext db) =>
+{
+    var reports = await db.Reports
+        .Include(r => r.User)
+        .OrderByDescending(r => r.CreatedAtUtc)
+        .ToListAsync();
+    return Results.Ok(reports);
+})
+.WithName("GetReports")
+.WithTags("Reports");
+
+app.MapPut("/api/reports/{id:int}/status", async (int id, string status, AppDbContext db) =>
+{
+    var report = await db.Reports.FindAsync(id);
+    if (report is null) return Results.NotFound();
+    if (!new[] { "Open", "Resolved" }.Contains(status))
+        return Results.BadRequest(new { error = "Status muss 'Open' oder 'Resolved' sein" });
+    report.Status = status;
+    await db.SaveChangesAsync();
+    return Results.Ok(report);
+})
+.WithName("UpdateReportStatus")
+.WithTags("Reports");
 
 
 // --------------------
@@ -329,6 +793,7 @@ public class AppDbContext : DbContext
 
     public DbSet<Ping>            Pings            => Set<Ping>();
     public DbSet<Area>            Areas            => Set<Area>();
+    public DbSet<Sector>          Sectors          => Set<Sector>();
     public DbSet<Route>           Routes           => Set<Route>();
     public DbSet<User>            Users            => Set<User>();
     public DbSet<Progress>        Progresses       => Set<Progress>();
@@ -339,6 +804,7 @@ public class AppDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        // Zusammengesetzter Primärschlüssel für die Subscribe-Tabelle
         modelBuilder.Entity<AppointmentUser>()
             .HasKey(au => new { au.AppointmentId, au.UserId });
     }

--- a/backend/ClimbConnect.API/Services/GradeConversionService.cs
+++ b/backend/ClimbConnect.API/Services/GradeConversionService.cs
@@ -1,0 +1,60 @@
+namespace ClimbConnect.API.Services;
+
+/// <summary>
+/// Konvertiert Klettergrade zwischen den Skalen Französisch (intern), UIAA und Amerikanisch.
+/// Intern wird immer die französische Skala gespeichert.
+/// </summary>
+public static class GradeConversionService
+{
+    /// <summary>
+    /// Zuordnungstabelle: Französisch → (UIAA, Amerikanisch).
+    /// Quelle: Standard-Konversionstabelle für Sportklettern.
+    /// </summary>
+    private static readonly Dictionary<string, (string Uiaa, string American)> GradeMap = new()
+    {
+        { "4",   ("IV",    "5.6")  },
+        { "4+",  ("IV+",   "5.7")  },
+        { "5",   ("V",     "5.8")  },
+        { "5+",  ("V+",    "5.9")  },
+        { "6a",  ("VI",    "5.10a") },
+        { "6a+", ("VI+",   "5.10b") },
+        { "6b",  ("VII-",  "5.10c") },
+        { "6b+", ("VII",   "5.10d") },
+        { "6c",  ("VII+",  "5.11a") },
+        { "6c+", ("VII+",  "5.11b") },
+        { "7a",  ("VIII-", "5.11c") },
+        { "7a+", ("VIII",  "5.11d") },
+        { "7b",  ("VIII+", "5.12a") },
+        { "7b+", ("IX-",   "5.12b") },
+        { "7c",  ("IX",    "5.12c") },
+        { "7c+", ("IX+",   "5.12d") },
+        { "8a",  ("X-",    "5.13a") },
+        { "8a+", ("X",     "5.13b") },
+        { "8b",  ("X+",    "5.13c") },
+        { "8b+", ("XI-",   "5.13d") },
+        { "8c",  ("XI",    "5.14a") },
+        { "8c+", ("XI+",   "5.14b") },
+        { "9a",  ("XII-",  "5.15a") },
+    };
+
+    /// <summary>
+    /// Konvertiert einen französischen Grad in die gewünschte Skala.
+    /// </summary>
+    /// <param name="frenchGrade">Grad in der französischen Skala, z.B. "6b".</param>
+    /// <param name="scale">Zielskala: "french", "uiaa" oder "american".</param>
+    /// <returns>Konvertierter Grad oder null wenn unbekannt.</returns>
+    public static string? Convert(string? frenchGrade, string scale = "french")
+    {
+        if (string.IsNullOrWhiteSpace(frenchGrade)) return null;
+
+        var key = frenchGrade.ToLower().Trim();
+
+        return scale.ToLower() switch
+        {
+            "french"   => frenchGrade,
+            "uiaa"     => GradeMap.TryGetValue(key, out var u) ? u.Uiaa     : null,
+            "american" => GradeMap.TryGetValue(key, out var a) ? a.American : null,
+            _          => frenchGrade
+        };
+    }
+}

--- a/docs/aba-portal.md
+++ b/docs/aba-portal.md
@@ -1,0 +1,119 @@
+# ClimbConnect – ABA Portal Text
+
+---
+
+## Ausgangslage
+
+Seilklettern erfreut sich in Österreich wachsender Beliebtheit, doch wer in
+Oberösterreich nach verlässlichen Informationen zu Klettergebieten sucht,
+stößt schnell auf ein grundlegendes Problem: Informationen zu Gebieten,
+Zustiegen, Routen und aktuellen Bedingungen sind häufig veraltet, auf
+verschiedene Plattformen verstreut oder gar nicht digital verfügbar. Sogenannte
+Kletterführer (Topos) sind oft nur als gedruckte Bücher erhältlich und
+spiegeln nicht den aktuellen Zustand eines Gebiets wider. Hinweise auf
+gesperrte Zustiege, beschädigte Bohrhaken oder ausgebrochene Griffe werden
+bestenfalls in informellen WhatsApp-Gruppen oder Foren geteilt – ohne
+zentrale Anlaufstelle.
+
+Ein weiteres Problem betrifft besonders Einsteiger: Es fehlt ein digitales
+Werkzeug, das speziell für den Kontext des Kletterns entwickelt wurde und
+es ermöglicht, den persönlichen Fortschritt strukturiert zu dokumentieren.
+Klettern ist eine sehr individuelle Sportart – die Entwicklung von
+Schwierigkeitsgraden, die Art der Begehung (Toprope oder Vorstieg), die
+Anzahl der benötigten Versuche und die subjektive Einschätzung einer Route
+sind wichtige Parameter, die bisher nirgendwo gebündelt erfasst werden können.
+
+Hinzu kommt, dass es insbesondere für neue Kletterer schwierig ist, einen
+geeigneten Seilpartner für Outdoor-Touren zu finden. Wer von der Halle an
+den Fels wechseln möchte, benötigt einen Partner auf ähnlichem Niveau –
+doch ein passendes digitales Tool, das diese Vernetzung im Kontext von
+konkreten Klettergebieten ermöglicht, existiert bisher nicht.
+
+---
+
+## Untersuchungsanliegen der individuellen Themenstellungen
+
+**Robin Lehner – Backend & Systemarchitektur**
+Im Rahmen der Diplomarbeit wird untersucht, wie ein domänenspezifisches
+Datenmodell für Seilklettergebiete konzipiert und als REST-API umgesetzt
+werden kann. Dabei wird analysiert, wie Klettergebiete, Sektoren, Routen
+und Schwierigkeitsgrade strukturiert gespeichert und über eine API bereitgestellt
+werden können. Ein weiterer Schwerpunkt liegt auf der Integration einer
+rollenbasierten Authentifizierung mittels Keycloak sowie der automatisierten
+Bereitstellung der Anwendung über eine CI/CD-Pipeline. Zusätzlich wird
+untersucht, wie Fortschrittsdaten aggregiert und als Statistiken (z.B.
+Gradentwicklung über Zeit) aufbereitet werden können.
+
+**Mohamed Attia – Frontend-Architektur & Datendarstellung**
+Im Rahmen der Diplomarbeit wird untersucht, wie eine moderne Single-Page-Application
+mit Angular strukturiert und aufgebaut werden kann. Dabei wird analysiert, wie
+die Anwendung in wiederverwendbare Komponenten aufgeteilt, die Kommunikation
+mit der REST-API über einen zentralen Service-Layer abgewickelt und komplexe
+Daten wie Gradentwicklungen als interaktive Charts dargestellt werden können.
+Ein weiterer Schwerpunkt liegt auf der Verwaltung von Klettergebieten, Sektoren
+und Routen im Frontend sowie auf der Umsetzung einer konsistenten Benutzeroberfläche.
+
+**Faru Hamid – Frontend & Benutzerorientierte Features**
+Im Rahmen der Diplomarbeit wird untersucht, wie benutzerorientierte Features
+einer Webanwendung – insbesondere Fortschrittstracking, Terminplanung und
+Community-Funktionen – in Angular umgesetzt werden können. Dabei wird analysiert,
+wie Benutzerinteraktionen wie das Eintragen von Begehungen, das Beitreten zu
+Terminen und das Hochladen von Bildern in einer responsiven Oberfläche
+ansprechend und intuitiv gestaltet werden können. Ein weiterer Schwerpunkt
+liegt auf der nutzerfreundlichen Darstellung von Profil- und Statistikseiten.
+
+---
+
+## Zielsetzung
+
+Ziel der Diplomarbeit ist die Entwicklung der Webplattform ClimbConnect,
+die Seilklettergebiete in Oberösterreich zentral verwaltet und dokumentiert.
+Die Plattform soll eine verlässliche, aktuell gehaltene Datenbasis für
+Klettergebiete, Sektoren und Routen schaffen und gleichzeitig Funktionen
+für persönliches Fortschrittstracking sowie Community-Interaktion bieten.
+
+Darüber hinaus soll untersucht werden, wie moderne Webtechnologien –
+insbesondere eine .NET 8 REST-API mit Angular-Frontend, Keycloak-Authentifizierung
+und containerisiertem Deployment – im Rahmen einer Diplomarbeit eingesetzt
+und hinsichtlich Wartbarkeit, Erweiterbarkeit und Benutzerfreundlichkeit
+bewertet werden können.
+
+---
+
+## Geplantes Ergebnis der individuellen Themenstellungen
+
+**Robin Lehner – Backend & Systemarchitektur**
+Als Ergebnis entsteht eine vollständige REST-API auf Basis von .NET 8 Minimal
+API und Entity Framework Core mit PostgreSQL-Datenbank. Die API stellt alle
+notwendigen Endpunkte für die Verwaltung von Klettergebieten (Areas, Sektoren,
+Routen), das Fortschrittstracking (inkl. Gradentwicklung und subjektiver
+Routenbewertung), den Terminplaner sowie das Kommentar- und Meldesystem bereit.
+Schwierigkeitsgrade werden intern in der französischen Skala gespeichert und
+per API wahlweise in der französischen, amerikanischen oder UIAA-Skala
+ausgegeben. Die Anwendung ist durch Keycloak abgesichert und wird über eine
+GitHub Actions CI/CD-Pipeline automatisiert deployed.
+
+**Mohamed Attia – Frontend-Architektur & Datendarstellung**
+Als Ergebnis entsteht eine strukturierte Angular-Anwendung mit klarer
+Komponentenarchitektur, zentralem HTTP-Service-Layer und durchgängigem
+Routing-Konzept. Mohamed verantwortet dabei insbesondere die Umsetzung
+der Gebiets- und Routenverwaltung im Frontend sowie die Integration von
+interaktiven Charts zur Darstellung der Gradentwicklung über Zeit.
+Die Anwendung kommuniziert vollständig über die REST-API und ist so
+aufgebaut, dass neue Features ohne großen Aufwand ergänzt werden können.
+
+**Faru Hamid – Frontend & Benutzerorientierte Features**
+Als Ergebnis entstehen die benutzerorientierten Kernbereiche der Anwendung:
+das persönliche Profil mit Fortschrittsübersicht, die Detailansichten für
+Routen und Begehungen, der Terminplaner mit Beitritt-Funktion sowie das
+Kommentar- und Meldesystem inklusive Bild-Upload. Faru verantwortet
+außerdem die responsive Gestaltung der Anwendung, sodass ClimbConnect
+sowohl am Desktop als auch am Mobilgerät einwandfrei nutzbar ist.
+
+**Gemeinsamer agiler Ansatz**
+Die Entwicklung erfolgt nach einem agilen Vorgehensmodell. Alle drei
+Teammitglieder arbeiten iterativ an gemeinsamen User Stories, unterstützen
+sich gegenseitig und sind in alle Bereiche des Projekts eingebunden.
+Die beschriebenen Schwerpunkte spiegeln die jeweilige Hauptverantwortung
+wider, nicht eine strikte Trennung der Aufgaben.
+

--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -1,0 +1,112 @@
+# ER-Diagramm – ClimbConnect (v2)
+
+```mermaid
+erDiagram
+    AREA {
+        int Id PK
+        string Name
+        string Description
+        string Location
+        string ImageUrl
+    }
+    SEKTOR {
+        int Id PK
+        int AreaId FK
+        string Name
+        string Description
+    }
+    ROUTE {
+        int Id PK
+        int SektorId FK
+        string Name
+        string Grade
+        string Style
+        int LengthM
+        string Description
+    }
+    USER {
+        int Id PK
+        string KeycloakId
+        string Username
+        string Email
+        string Bio
+        datetime CreatedAt
+    }
+    PROGRESS {
+        int Id PK
+        int UserId FK
+        int RouteId FK
+        string Status
+        string Begehungsart
+        int AnzahlVersuche
+        datetime Date
+        string Notes
+    }
+    APPOINTMENT {
+        int Id PK
+        int AreaId FK
+        int CreatedById FK
+        string Title
+        string Description
+        datetime Date
+        int MaxParticipants
+    }
+    APPOINTMENT_USER {
+        int AppointmentId FK
+        int UserId FK
+        datetime RegisteredAt
+    }
+    COMMENT {
+        int Id PK
+        int UserId FK
+        int RouteId FK "nullable"
+        int AreaId FK "nullable"
+        string Text
+        string PhotoUrl
+        datetime CreatedAt
+    }
+    REPORT {
+        int Id PK
+        int RouteId FK
+        int UserId FK
+        string Description
+        string Severity
+        string PhotoUrl
+        datetime CreatedAt
+    }
+
+    AREA ||--o{ SEKTOR : "hat"
+    SEKTOR ||--o{ ROUTE : "hat"
+    AREA ||--o{ APPOINTMENT : "hostet"
+    USER ||--o{ PROGRESS : "erfasst"
+    ROUTE ||--o{ PROGRESS : "hat"
+    USER ||--o{ COMMENT : "schreibt"
+    ROUTE ||--o{ COMMENT : "hat"
+    AREA ||--o{ COMMENT : "hat"
+    USER ||--o{ REPORT : "meldet"
+    ROUTE ||--o{ REPORT : "hat"
+    APPOINTMENT ||--o{ APPOINTMENT_USER : "hat"
+    USER ||--o{ APPOINTMENT_USER : "registriert"
+    USER ||--o{ APPOINTMENT : "erstellt"
+```
+
+## Änderungen gegenüber v1
+
+| Was | Warum |
+|---|---|
+| `SEKTOR` neu zwischen Area und Route | Laut ABA-Portal: "Sektoren, Routen, Schwierigkeitsgrade" |
+| `Route.SektorId` statt `AreaId` | Route gehört zu einem Sektor, nicht direkt zum Gebiet |
+| `Progress.Begehungsart` (Toprope/Vorstieg) | Explizit im ABA-Portal erwähnt |
+| `Progress.AnzahlVersuche` | "benötigte Versuche" laut ABA-Portal |
+| `Progress.Status` = Projekt/Rotpunkt/Flash/Onsight | Standard-Kletterterminologie |
+| `Comment.RouteId` + `Comment.AreaId` nullable | Kommentare zu Gebieten ODER Routen möglich |
+| `Comment.PhotoUrl` | "Bilder zu Gebieten/Routen" laut ABA-Portal |
+| `User.KeycloakId` statt `PasswordHash` | Auth via Keycloak, kein eigenes Passwort |
+
+## Enums
+
+**Progress.Status:** `Projekt` · `Rotpunkt` · `Flash` · `Onsight`
+
+**Progress.Begehungsart:** `Toprope` · `Vorstieg`
+
+**Report.Severity:** `Low` · `Medium` · `High`

--- a/docs/meilensteine.md
+++ b/docs/meilensteine.md
@@ -1,0 +1,138 @@
+# ClimbConnect – Meilensteine
+
+## Meilenstein 1 — „Die App läuft und ich kann mich anmelden"
+
+Jemand der den Link zu ClimbConnect bekommt, kann die Webseite im Browser
+aufrufen – egal ob am Handy oder PC, egal wo auf der Welt. Die Seite ist
+zwar noch leer (keine Gebiete, keine Routen), aber sie ist live und
+funktionsfähig deployed. Ein neuer Benutzer kann sich mit seiner E-Mail-Adresse
+und einem Passwort registrieren, einloggen und wird auf sein persönliches
+Dashboard weitergeleitet. Er kann seinen Benutzernamen, sein bevorzugtes
+Gradierungssystem (Französisch, UIAA oder Amerikanisch) und seinen
+durchschnittlichen Klettergrad im Profil hinterlegen.
+
+**Was der Benutzer kann:**
+- Webseite im Browser aufrufen (live deployed, kein lokales Setup nötig)
+- Konto erstellen (Registrierung mit E-Mail und Passwort)
+- Einloggen und ausloggen
+- Eigenes Profil anlegen (Name, Klettergrad, bevorzugte Gradskala)
+
+---
+
+## Meilenstein 2 — „Ich kann Klettergebiete und Routen nachschlagen"
+
+Ein Benutzer öffnet die App und sieht eine Übersicht aller eingetragenen
+Klettergebiete in Oberösterreich. Direkt in der Liste sieht er bei jedem
+Gebiet wie viele Leute laut Terminplaner heute dort klettern und wie viele
+vorhaben zu kommen. Er kann ein Gebiet anklicken und sieht alle Sektoren
+(z.B. „Nordwand", „Hauptsektor"). Innerhalb eines Sektors sieht er alle
+Routen mit Name, Schwierigkeitsgrad in seinem bevorzugten System, Stil
+und Länge – ohne sich einloggen zu müssen.
+
+**Was der Benutzer kann:**
+- Liste aller Klettergebiete ansehen inkl. aktuellem Besucherandrang
+- Sektoren und Routen eines Gebiets ansehen
+- Schwierigkeitsgrade in seiner bevorzugten Skala sehen (Französisch/UIAA/Amerikanisch)
+- Gebiete und Routen durchsuchen
+
+---
+
+## Meilenstein 3 — „Die Gebiete, Sektoren und Routen sind gepflegt"
+
+Die Datenbank der OÖ-Klettergebiete wird von den Administratoren der Plattform
+gepflegt. Ein Administrator kann Klettergebiete anlegen, Sektoren zuweisen und
+Routen mit Schwierigkeitsgrad, Stil und Länge erfassen. Bestehende Einträge
+können bearbeitet oder gelöscht werden. Der eingetragene Grad wird automatisch
+in alle drei Skalen umgerechnet und je nach Profileinstellung des jeweiligen
+Benutzers in der App angezeigt.
+
+Normale Benutzer haben keinen Schreibzugriff auf Gebiete, Sektoren oder Routen.
+Sie können jedoch über die Kommentarfunktion Feedback zu einzelnen Routen
+hinterlassen – zum Beispiel wenn sich der Grad leichter oder schwerer anfühlt
+als angegeben, und warum (z.B. abgegriffene Griffe, neue Sicherung).
+
+**Was der Administrator kann:**
+- Neues Klettergebiet anlegen (Name, Beschreibung, Standort, Bild)
+- Sektoren zu einem Gebiet hinzufügen
+- Routen mit Grad, Stil und Länge anlegen
+- Gebiete, Sektoren und Routen bearbeiten und löschen
+
+**Was der normale Benutzer kann:**
+- Alle Gebiete, Sektoren und Routen ansehen
+- Kommentar zur subjektiven Schwierigkeit einer Route schreiben
+  (z.B. „Fühlt sich leichter an als 6b, Griffe sind gut geformt")
+- Subjektiven Grad mit kurzem Kommentar angeben
+  (fließt in den Community-Grad der Route ein)
+
+---
+
+## Meilenstein 4 — „Ich kann meinen Kletterfortschritt dokumentieren"
+
+Ein Benutzer hat heute eine Route rotpunkt geklettert – nach 3 Versuchen,
+im Vorstieg. Er trägt das in ClimbConnect ein: Status „Rotpunkt", Begehungsart
+„Vorstieg", 3 Versuche, optional eine Notiz. Er kann auch angeben wie schwer
+sich die Route im Vergleich zum offiziellen Grad angefühlt hat und einen
+kurzen Kommentar dazu schreiben (z.B. „Oberer Teil sehr abgegriffen").
+Routen die er noch übt markiert er als „Projekt". All seine Einträge
+sind im Profil gespeichert und jederzeit abrufbar.
+
+**Was der Benutzer kann:**
+- Gekletterte Route eintragen: Status, Begehungsart, Anzahl Versuche, Notiz
+- Subjektiven Grad + kurzen Kommentar zur Route angeben
+- Route als Projekt markieren
+- Alle eigenen Einträge in einer Übersicht sehen
+- Öffentliches Profil anderer User aufrufen und deren letzte Begehungen sehen
+
+---
+
+## Meilenstein 5 — „Ich sehe wie ich mich über Zeit verbessert habe"
+
+Ein Benutzer öffnet sein Profil und sieht ein Diagramm seiner Gradentwicklung:
+auf der X-Achse die Zeit (Monate), auf der Y-Achse der höchste Grad den er
+rotpunkt geklettert hat – in seiner bevorzugten Skala. Er sieht auf einen Blick
+wie er sich über die Saison gesteigert hat. Außerdem sieht er eine Übersicht
+seiner Gesamtstatistik: wie viele Routen er geklettert ist, wie viele Projekte
+noch offen sind und in welchem Gebiet er am meisten geklettert hat.
+
+**Was der Benutzer kann:**
+- Gradentwicklung über Zeit als Chart sehen (in seiner bevorzugten Skala)
+- Gesamtanzahl gekletterte Routen sehen
+- Anzahl offener Projekte sehen
+- Lieblingsgebiet anhand eigener Einträge sehen
+
+---
+
+## Meilenstein 6 — „Ich kann aktuelle Informationen zu Routen und Gebieten teilen"
+
+Ein Benutzer war am Traunstein klettern und hat einen beschädigten Bohrhaken
+entdeckt. Er öffnet ClimbConnect, navigiert zur Route und schreibt einen
+Kommentar mit Foto und dem Hinweis auf den Schaden. Andere Kletterer sehen
+diesen Hinweis sofort. Für kritische Sicherheitsprobleme kann er zusätzlich
+einen Safety-Report mit Schweregrad erstellen – damit das Problem klar
+gekennzeichnet ist und nicht übersehen wird.
+
+**Was der Benutzer kann:**
+- Kommentar mit Text und Foto zu einem Gebiet oder einer Route schreiben
+- Kommentare anderer Benutzer lesen
+- Safety-Report zu einer Route erstellen (Schweregrad: Niedrig/Mittel/Hoch, Foto)
+- Safety-Reports einer Route einsehen
+
+---
+
+## Meilenstein 7 — „Ich kann Kletterpartner finden"
+
+Ein Benutzer plant für Samstag einen Ausflug zum Gmundnerberg und möchte
+nicht alleine fahren. Er erstellt einen Termin: Gebiet, Datum, Uhrzeit,
+kurze Beschreibung, Mindestens 2 und maximal 5 Teilnehmer. Andere Benutzer
+sehen den Termin, können den Durchschnittsgrad der aktuellen Gruppe sehen
+und beitreten wenn sie auf ähnlichem Niveau klettern. Für neue Kletterer
+die noch nie draußen waren ist das die einfachste Möglichkeit einen
+erfahrenen Seilpartner zu finden.
+
+**Was der Benutzer kann:**
+- Klettertermin für ein Gebiet erstellen (Datum, Uhrzeit, Beschreibung, Min./Max. Teilnehmer)
+- Offene Termine sehen und beitreten
+- Durchschnittsgrad der Gruppe sehen (in seiner bevorzugten Skala)
+- Einem Termin wieder austreten
+- Eigene Termine bearbeiten und löschen
+

--- a/docs/pitch.md
+++ b/docs/pitch.md
@@ -1,0 +1,117 @@
+# ClimbConnect – Projektpitch
+
+Stell dir vor, du kletterst seit einem Jahr in der Halle und willst endlich
+auch mal draußen am Fels klettern. Du suchst online nach Gebieten in
+Oberösterreich – findest aber kaum verlässliche Informationen. Die meisten
+Daten sind veraltet, verstreut oder nur als gedruckter Kletterführer erhältlich.
+Ob ein Zustieg noch frei ist, ob ein Griff ausgebrochen ist oder ob ein
+Bohrhaken erneuert wurde – das erfährt man bestenfalls zufällig in einer
+WhatsApp-Gruppe.
+
+Dazu kommt: Du weißt nicht, wen du fragen sollst oder wie du jemanden auf
+ähnlichem Level findest, der mitkommen will. Für Einsteiger ins Outdoor-Klettern
+ist genau das oft die größte Hürde.
+
+**Genau hier setzt ClimbConnect an.**
+
+---
+
+## Was ist ClimbConnect?
+
+ClimbConnect ist eine Webplattform die Seilklettergebiete in Oberösterreich
+zentral erfasst, persönliche Fortschritte dokumentiert und Kletterer für
+gemeinsame Ausflüge vernetzt. Der Fokus liegt bewusst auf Seilklettern –
+nicht auf Bouldern – weil es in OÖ sehr viele Gebiete gibt und die
+Informationslage dort besonders lückenhaft ist.
+
+---
+
+## Die wichtigsten Features
+
+**Gebiete, Sektoren & Routen**
+Alle Seilklettergebiete in Oberösterreich an einem Ort – strukturiert nach
+Gebieten, Sektoren (z.B. „Nordwand") und einzelnen Routen. Jede Route hat
+Name, Schwierigkeitsgrad, Stil und Länge. Schwierigkeitsgrade werden in
+der gewählten Skala des Benutzers angezeigt: Französisch (6b), UIAA (VII-)
+oder Amerikanisch (5.10d) – einmal einstellen, überall angezeigt.
+
+**Fortschritt tracken**
+Benutzer können festhalten welche Routen sie geklettert haben: Status
+(Rotpunkt, Flash, Onsight oder noch als Projekt offen), Begehungsart
+(Toprope oder Vorstieg), Anzahl der Versuche und eine persönliche Notiz.
+Wer das Gefühl hat, dass eine Route sich anders anfühlt als ihr offizieller
+Grad – zum Beispiel weil die Griffe abgegriffen sind – kann eine subjektive
+Bewertung mit kurzem Kommentar abgeben. Aus allen Bewertungen entsteht
+automatisch ein Community-Grad pro Route.
+
+**Entwicklung sehen**
+Im persönlichen Profil sieht man die eigene Gradentwicklung als Chart über
+Zeit: Wann hat man welchen Schwierigkeitsgrad rotpunkt geklettert? So sieht
+man auf einen Blick wie man sich über die Saison verbessert hat – und bleibt
+motiviert.
+
+**Wer ist heute dort?**
+Direkt in der Gebietsübersicht sieht man wie viele Leute laut Terminplaner
+heute in einem Gebiet klettern und wie viele vorhaben zu kommen. So weiß man
+schon vor dem Fahren ob ein Gebiet gerade voll ist.
+
+**Kletterpartner finden**
+Über den Terminplaner kann man für einen bestimmten Tag in einem Gebiet einen
+Termin erstellen – mit Mindest- und Maximalanzahl an Teilnehmern. Andere
+Benutzer können beitreten. Der Durchschnittsgrad der Gruppe ist für alle
+sichtbar, damit man einschätzen kann ob das Level passt. Das ist kein Social
+Media – es gibt keinen Chat, kein Follow-System. Nur ein einfaches Tool um
+gemeinsam Klettern zu planen.
+
+**Aktuelle Informationen teilen**
+Benutzer können Kommentare mit Fotos zu Gebieten oder einzelnen Routen
+schreiben – zum Beispiel wenn ein Zustieg gesperrt ist oder sich die
+Bedingungen geändert haben. Für Sicherheitsprobleme wie lockere Griffe oder
+beschädigte Haken gibt es zusätzlich eine Meldefunktion mit Schweregrad.
+
+---
+
+## Technik
+
+- **Backend:** C# mit .NET 8 Minimal API und Entity Framework Core
+- **Datenbank:** PostgreSQL
+- **Authentifizierung:** Keycloak (Login, Registrierung, Rollenverwaltung)
+- **Frontend:** Angular
+- **Deployment:** Automatisiert über GitHub Actions CI/CD Pipeline
+- **Skalierung:** Durch modularen Aufbau einfach auf weitere Bundesländer
+  oder Sportarten erweiterbar
+
+---
+
+## Individuelle Beiträge
+
+**Robin Lehner – Backend & Systemarchitektur**
+Konzeption und Implementierung des domänenspezifischen Datenmodells
+(Gebiete → Sektoren → Routen), der REST-API mit allen Endpunkten, der
+Keycloak-Authentifizierung sowie der CI/CD-Pipeline und des Deployments.
+
+**Mohamed Attia – Frontend-Architektur & Datendarstellung**
+Aufbau der Angular-Anwendung, Komponentenstruktur, Service-Layer für die
+API-Kommunikation, Verwaltungsansichten für Gebiete und Routen sowie die
+interaktiven Charts für die Gradentwicklung.
+
+**Faru Hamid – Frontend & Benutzerorientierte Features**
+Profil und Fortschrittsansichten, Terminplaner-UI, Kommentar- und Meldesystem
+mit Bild-Upload sowie responsive Gestaltung für Desktop und Mobilgerät.
+
+Alle drei Teammitglieder arbeiten nach einem agilen Vorgehensmodell –
+jeder unterstützt die anderen und ist in alle Bereiche des Projekts eingebunden.
+
+---
+
+## Ausblick
+
+ClimbConnect startet mit Seilklettergebieten in Oberösterreich. Langfristig
+ist eine Erweiterung auf andere Bundesländer wie Salzburg oder Niederösterreich
+denkbar – sowie die Integration von Bouldergebieten. Die modulare Architektur
+macht genau das möglich.
+
+Unser Ziel: Eine Plattform die Kletterer beim Klettern wirklich begleitet –
+nicht nur als Informationsquelle, sondern als persönliches Notizbuch,
+Trainingstagbuch und Planungstool in einem.
+


### PR DESCRIPTION
## Was wurde gemacht

### Neue Entity: Sector
Die Hierarchie ist jetzt **Area → Sector → Route** statt Area → Route.

### Model-Erweiterungen
- `Route` — `AreaId` ersetzt durch `SectorId`
- `Progress` — `ClimbingStyle` (Toprope/Vorstieg), `SubjectiveGrade`, `SubjectiveGradeComment`
- `Report` — `Severity` (Low/Medium/High)
- `Appointment` — `MinParticipants`, `MaxParticipants`

### Neuer Service
- `GradeConversionService` — konvertiert Grad zwischen französisch, UIAA und amerikanisch

### Alle Endpoints implementiert
Areas, Sectors, Routes, Progress, Appointments, Comments, Reports

### Grad-Konversion
Route-Endpoints akzeptieren `?scale=french|uiaa|american`

## Test plan
- [ ] `dotnet build` 0 Fehler
- [ ] POST /api/areas → POST /api/areas/{id}/sectors → POST /api/sectors/{id}/routes
- [ ] GET /api/sectors/{id}/routes?scale=uiaa
- [ ] POST /api/progress mit ClimbingStyle und SubjectiveGrade
- [ ] POST /api/reports mit Severity
- [ ] POST /api/appointments/{id}/subscribe → Konflikt bei MaxParticipants