### PR TITLE
feat: User-Statistiken, oeffentliche Profile, Docker Compose (closes #102, #106, #107)

### DIFF
--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -768,6 +768,100 @@ app.MapPut("/api/reports/{id:int}/status", async (int id, string status, AppDbCo
 .WithTags("Reports");
 
 
+// --------------------
+// USER STATISTIKEN
+// --------------------
+app.MapGet("/api/users/{id:int}/stats", async (int id, string? scale, AppDbContext db) =>
+{
+    if (!await db.Users.AnyAsync(u => u.Id == id)) return Results.NotFound();
+
+    var progresses = await db.Progresses
+        .Where(p => p.UserId == id)
+        .Include(p => p.Route)
+            .ThenInclude(r => r.Sector)
+                .ThenInclude(s => s.Area)
+        .ToListAsync();
+
+    // Gekletterte Routen (alles außer Projekt)
+    var ascents   = progresses.Where(p => p.Status != "Projekt").ToList();
+    var projects  = progresses.Where(p => p.Status == "Projekt").ToList();
+
+    // Lieblingsgebiet: Gebiet mit den meisten Begehungen
+    var favoriteArea = ascents
+        .GroupBy(p => p.Route.Sector.Area.Name)
+        .OrderByDescending(g => g.Count())
+        .Select(g => g.Key)
+        .FirstOrDefault();
+
+    // Grad-Entwicklung: höchster Rotpunkt-/Flash-/Onsight-Grad pro Monat
+    var targetScale = scale ?? "french";
+    var gradeProgression = ascents
+        .Where(p => p.Route.Grade != null)
+        .GroupBy(p => new { p.Date.Year, p.Date.Month })
+        .OrderBy(g => g.Key.Year).ThenBy(g => g.Key.Month)
+        .Select(g =>
+        {
+            var best = g.OrderByDescending(p => GradeConversionService.Rank(p.Route.Grade)).First();
+            return new
+            {
+                Month = $"{g.Key.Year:0000}-{g.Key.Month:00}",
+                Grade = GradeConversionService.Convert(best.Route.Grade, targetScale)
+            };
+        })
+        .ToList();
+
+    return Results.Ok(new
+    {
+        TotalClimbed     = ascents.Count,
+        OpenProjects     = projects.Count,
+        FavoriteArea     = favoriteArea,
+        GradeProgression = gradeProgression
+    });
+})
+.WithName("GetUserStats")
+.WithTags("Users");
+
+
+// --------------------
+// OEFFENTLICHE PROFILE
+// --------------------
+app.MapGet("/api/users/{id:int}/profile", async (int id, string? scale, AppDbContext db) =>
+{
+    var user = await db.Users.FindAsync(id);
+    if (user is null) return Results.NotFound();
+
+    var targetScale = scale ?? "french";
+
+    // Letzte 10 Begehungen (kein Projekt)
+    var recentAscents = await db.Progresses
+        .Where(p => p.UserId == id && p.Status != "Projekt")
+        .Include(p => p.Route)
+            .ThenInclude(r => r.Sector)
+                .ThenInclude(s => s.Area)
+        .OrderByDescending(p => p.Date)
+        .Take(10)
+        .Select(p => new
+        {
+            RouteName = p.Route.Name,
+            Grade     = GradeConversionService.Convert(p.Route.Grade, targetScale),
+            Area      = p.Route.Sector.Area.Name,
+            p.Date,
+            p.Status
+        })
+        .ToListAsync();
+
+    return Results.Ok(new
+    {
+        user.Id,
+        user.Username,
+        MemberSince   = user.CreatedAtUtc.ToString("yyyy-MM-dd"),
+        RecentAscents = recentAscents
+    });
+})
+.WithName("GetUserProfile")
+.WithTags("Users");
+
+
 app.Run();
 
 

--- a/backend/ClimbConnect.API/Services/GradeConversionService.cs
+++ b/backend/ClimbConnect.API/Services/GradeConversionService.cs
@@ -38,6 +38,30 @@ public static class GradeConversionService
     };
 
     /// <summary>
+    /// Sortierreihenfolge für französische Grade (niedriger = einfacher).
+    /// Wird für die Grad-Entwicklung im Stats-Endpoint verwendet.
+    /// </summary>
+    private static readonly List<string> GradeOrder =
+    [
+        "4", "4+", "5", "5a", "5b", "5+", "5c",
+        "6a", "6a+", "6b", "6b+", "6c", "6c+",
+        "7a", "7a+", "7b", "7b+", "7c", "7c+",
+        "8a", "8a+", "8b", "8b+", "8c", "8c+",
+        "9a", "9a+", "9b", "9b+", "9c"
+    ];
+
+    /// <summary>
+    /// Gibt den numerischen Rang eines Grads zurück — höher = schwerer.
+    /// Gibt -1 zurück wenn der Grad unbekannt ist.
+    /// </summary>
+    public static int Rank(string? frenchGrade)
+    {
+        if (string.IsNullOrWhiteSpace(frenchGrade)) return -1;
+        var idx = GradeOrder.IndexOf(frenchGrade.ToLower().Trim());
+        return idx;
+    }
+
+    /// <summary>
     /// Konvertiert einen französischen Grad in die gewünschte Skala.
     /// </summary>
     /// <param name="frenchGrade">Grad in der französischen Skala, z.B. "6b".</param>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,30 +7,29 @@ services:
       - "5004:8080"
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ConnectionStrings__DefaultConnection=Data Source=Data/ClimbConnect.db;
-      - Keycloak__AuthServerUrl=http://keycloak:8080
-      - Keycloak__Realm=climbconnect
-      - Keycloak__Resource=climbconnect-api
+      - ConnectionStrings__DefaultConnection=Data Source=/app/Data/ClimbConnect.db;
+      - Jwt__Key=ClimbConnect-SuperSecret-Key-MinLength-32-Chars!
+      - Jwt__Issuer=climbconnect-api
+      - Jwt__Audience=climbconnect-ui
+      - Jwt__ExpiryHours=24
     volumes:
       - climbconnect-data:/app/Data
-    depends_on:
-      keycloak:
-        condition: service_healthy
-
-  keycloak:
-    image: quay.io/keycloak/keycloak:26.2
-    ports:
-      - "8080:8080"
-    environment:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
-    command: start-dev
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready || exit 1"]
-      interval: 15s
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/api/health || exit 1"]
+      interval: 10s
       timeout: 5s
-      retries: 12
-      start_period: 60s
+      retries: 5
+      start_period: 20s
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "4200:8080"
+    depends_on:
+      api:
+        condition: service_healthy
 
 volumes:
   climbconnect-data:


### PR DESCRIPTION
## Was wurde implementiert

- #106 GET /api/users/{id}/stats - Anzahl Begehungen, offene Projekte, Lieblingsgebiet, Grad-Entwicklung pro Monat (unterstuetzt ?scale=french|uiaa|american)
- #107 GET /api/users/{id}/profile - oeffentliches Profil mit Username, Mitglied-seit, letzte 10 Begehungen
- GradeConversionService um Rank()-Methode erweitert (fuer Grad-Vergleich in Statistiken)
- #102 docker-compose.yml: Keycloak entfernt, JWT-Konfiguration als Env-Vars, Healthcheck fuer API, Frontend wartet auf API
- #8 #9 #10 Bereits implementierte Issues auf GitHub geschlossen

## Test plan
- [ ] GET /api/users/1/stats -> Statistiken sehen
- [ ] GET /api/users/1/stats?scale=uiaa -> Grad in UIAA-Skala
- [ ] GET /api/users/1/profile -> Profil und letzte Begehungen
- [ ] docker compose up -> API + Frontend starten (kein Keycloak mehr noetig)

Generated with Claude Code
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>