### PR TITLE
feat: Bild-Upload fuer Kommentare (closes #111)

### DIFF
--- a/backend/ClimbConnect.API/Dtos/CommentCreateDto.cs
+++ b/backend/ClimbConnect.API/Dtos/CommentCreateDto.cs
@@ -1,3 +1,4 @@
 namespace ClimbConnect.API.Dtos;
 
-public record CommentCreateDto(int UserId, string Text);
+/// <summary>Daten für einen neuen Kommentar. PhotoUrl ist optional.</summary>
+public record CommentCreateDto(string Text, string? PhotoUrl = null);

--- a/backend/ClimbConnect.API/Migrations/20260607092757_AddCommentPhotoUrl.Designer.cs
+++ b/backend/ClimbConnect.API/Migrations/20260607092757_AddCommentPhotoUrl.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ClimbConnect.API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260607092757_AddCommentPhotoUrl")]
+    partial class AddCommentPhotoUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.0");

--- a/backend/ClimbConnect.API/Migrations/20260607092757_AddCommentPhotoUrl.cs
+++ b/backend/ClimbConnect.API/Migrations/20260607092757_AddCommentPhotoUrl.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ClimbConnect.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommentPhotoUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PhotoUrl",
+                table: "Comments",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PhotoUrl",
+                table: "Comments");
+        }
+    }
+}

--- a/backend/ClimbConnect.API/Models/Comment.cs
+++ b/backend/ClimbConnect.API/Models/Comment.cs
@@ -7,6 +7,10 @@ public class Comment
     public int? AreaId { get; set; }
     public int? RouteId { get; set; }
     public string Text { get; set; } = string.Empty;
+
+    /// <summary>Optionaler Pfad zum hochgeladenen Foto, z.B. "/uploads/abc123.jpg".</summary>
+    public string? PhotoUrl { get; set; }
+
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
     public User User { get; set; } = null!;

--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -135,6 +135,18 @@ app.UseAuthorization();
 // HTTP-Request-Logging
 app.UseHttpLogging();
 
+// Statische Dateien für hochgeladene Bilder (erreichbar unter /uploads/...)
+var uploadsPath = Path.Combine(
+    AppDomain.CurrentDomain.GetData("DataDirectory") as string
+        ?? AppDomain.CurrentDomain.BaseDirectory,
+    "uploads");
+Directory.CreateDirectory(uploadsPath);
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(uploadsPath),
+    RequestPath  = "/uploads"
+});
+
 // Migrations bei App-Start automatisch anwenden + Seed-Daten einspielen
 using (var scope = app.Services.CreateScope())
 {
@@ -150,6 +162,37 @@ using (var scope = app.Services.CreateScope())
 app.MapGet("/api/health", () =>
     Results.Ok(new { status = "ok" }))
    .WithName("Health");
+
+
+// --------------------
+// UPLOAD
+// --------------------
+app.MapPost("/api/upload", async (IFormFile file, HttpContext ctx) =>
+{
+    var allowed = new[] { "image/jpeg", "image/png", "image/webp", "image/gif" };
+    if (!allowed.Contains(file.ContentType))
+        return Results.BadRequest(new { error = "Nur JPG, PNG, WebP und GIF sind erlaubt." });
+
+    if (file.Length > 5 * 1024 * 1024)
+        return Results.BadRequest(new { error = "Maximale Dateigröße ist 5 MB." });
+
+    var ext      = Path.GetExtension(file.FileName).ToLower();
+    var fileName = $"{Guid.NewGuid()}{ext}";
+    var savePath = Path.Combine(
+        AppDomain.CurrentDomain.GetData("DataDirectory") as string
+            ?? AppDomain.CurrentDomain.BaseDirectory,
+        "uploads", fileName);
+
+    await using var stream = File.Create(savePath);
+    await file.CopyToAsync(stream);
+
+    var url = $"/uploads/{fileName}";
+    return Results.Ok(new { url });
+})
+.WithName("UploadImage")
+.WithTags("Upload")
+.RequireAuthorization("User")
+.DisableAntiforgery();
 
 
 // --------------------
@@ -665,7 +708,13 @@ app.MapPost("/api/areas/{id:int}/comments", async (int id, CommentCreateDto dto,
     if (string.IsNullOrWhiteSpace(dto.Text))
         return Results.BadRequest(new { error = "Text is required" });
 
-    var comment = new Comment { UserId = userId, AreaId = id, Text = dto.Text.Trim() };
+    var comment = new Comment
+    {
+        UserId   = userId,
+        AreaId   = id,
+        Text     = dto.Text.Trim(),
+        PhotoUrl = string.IsNullOrWhiteSpace(dto.PhotoUrl) ? null : dto.PhotoUrl.Trim()
+    };
     db.Comments.Add(comment);
     await db.SaveChangesAsync();
     return Results.Created($"/api/areas/{id}/comments", comment);
@@ -695,7 +744,13 @@ app.MapPost("/api/routes/{id:int}/comments", async (int id, CommentCreateDto dto
     if (string.IsNullOrWhiteSpace(dto.Text))
         return Results.BadRequest(new { error = "Text is required" });
 
-    var comment = new Comment { UserId = userId, RouteId = id, Text = dto.Text.Trim() };
+    var comment = new Comment
+    {
+        UserId   = userId,
+        RouteId  = id,
+        Text     = dto.Text.Trim(),
+        PhotoUrl = string.IsNullOrWhiteSpace(dto.PhotoUrl) ? null : dto.PhotoUrl.Trim()
+    };
     db.Comments.Add(comment);
     await db.SaveChangesAsync();
     return Results.Created($"/api/routes/{id}/comments", comment);


### PR DESCRIPTION
## Was wurde implementiert

- POST /api/upload - Bild hochladen (multipart/form-data), gibt URL zurueck
  - Nur JPG, PNG, WebP, GIF erlaubt
  - Max. 5 MB
  - Bilder werden im Data-Ordner gespeichert (Docker-Volume-kompatibel)
  - Erreichbar unter /uploads/{dateiname}
- Comment-Model: PhotoUrl-Feld ergaenzt (optional)
- CommentCreateDto: optionale PhotoUrl
- EF Migration AddCommentPhotoUrl
- Static Files Middleware fuer /uploads/

## Ablauf fuer das Frontend
1. POST /api/upload mit dem Bild als multipart/form-data
2. URL aus der Antwort ({ url: /uploads/abc.jpg }) merken
3. POST /api/areas/{id}/comments mit { text: ..., photoUrl: /uploads/abc.jpg }

## Test plan
- [ ] POST /api/upload mit einem JPG -> url erhalten
- [ ] GET /uploads/{dateiname} -> Bild sehen
- [ ] POST /api/areas/1/comments mit photoUrl -> Kommentar mit Foto
- [ ] GET /api/areas/1/comments -> photoUrl im Response sichtbar
- [ ] Upload mit > 5MB -> 400 Bad Request
- [ ] Upload mit PDF -> 400 Bad Request

Generated with Claude Code
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>