### PR TITLE
fix: Data-Ordner beim Start erstellen (SQLite Startup-Fehler)

### DIFF
--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -147,6 +147,11 @@ app.UseStaticFiles(new StaticFileOptions
     RequestPath  = "/uploads"
 });
 
+// Data-Ordner sicherstellen (SQLite braucht das Verzeichnis)
+var dataDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data");
+Directory.CreateDirectory(dataDir);
+AppDomain.CurrentDomain.SetData("DataDirectory", AppDomain.CurrentDomain.BaseDirectory);
+
 // Migrations bei App-Start automatisch anwenden + Seed-Daten einspielen
 using (var scope = app.Services.CreateScope())
 {


### PR DESCRIPTION
## Problem
SQLite konnte die Datenbankdatei nicht oeffnen weil der Data-Ordner noch nicht existiert.
Fehler: SQLite Error 14: unable to open database file

## Fix
Data-Ordner wird beim App-Start automatisch erstellt bevor Migrations laufen.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>