### PR TITLE
fix: Sicherheitsprobleme behoben (CORS, Swagger, Auth, JWT-Secret)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ Thumbs.db
 # Env & secrets
 .env
 **/*.secrets.json
+# Produktions-Secrets niemals in appsettings einchecken!
+# JWT-Key in Produktion per Umgebungsvariable Jwt__Key setzen.

--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -53,7 +53,15 @@ builder.Services.AddSwaggerGen(c =>
 // --------------------
 // CORS
 // --------------------
-builder.Services.AddCors();
+var allowedOrigins = builder.Configuration
+    .GetSection("Cors:AllowedOrigins")
+    .Get<string[]>() ?? [];
+
+builder.Services.AddCors(options =>
+    options.AddDefaultPolicy(policy =>
+        policy.WithOrigins(allowedOrigins)
+              .AllowAnyHeader()
+              .AllowAnyMethod()));
 
 // --------------------
 // HTTP LOGGING
@@ -137,13 +145,16 @@ app.UseExceptionHandler(errApp => errApp.Run(async ctx =>
 }));
 
 // --------------------
-// SWAGGER UI
+// SWAGGER UI (nur in Development)
 // --------------------
-app.UseSwagger();
-app.UseSwaggerUI();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 app.UseHttpsRedirection();
-app.UseCors(b => b.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin());
+app.UseCors();
 app.UseAuthentication();
 app.UseAuthorization();
 
@@ -827,7 +838,8 @@ app.MapGet("/api/reports", async (AppDbContext db) =>
     return Results.Ok(reports);
 })
 .WithName("GetReports")
-.WithTags("Reports");
+.WithTags("Reports")
+.RequireAuthorization("Admin");
 
 app.MapPut("/api/reports/{id:int}/status", async (int id, string status, AppDbContext db) =>
 {
@@ -840,7 +852,8 @@ app.MapPut("/api/reports/{id:int}/status", async (int id, string status, AppDbCo
     return Results.Ok(report);
 })
 .WithName("UpdateReportStatus")
-.WithTags("Reports");
+.WithTags("Reports")
+.RequireAuthorization("Admin");
 
 
 // --------------------

--- a/backend/ClimbConnect.API/appsettings.Development.json
+++ b/backend/ClimbConnect.API/appsettings.Development.json
@@ -5,6 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Jwt": {
+    "Key": "ClimbConnect-Dev-Only-Key-Nicht-Fuer-Produktion!!"
+  },
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:4200", "http://localhost:3000" ]
+  },
   "Keycloak": {
     "AuthServerUrl": "http://localhost:8080"
   }

--- a/backend/ClimbConnect.API/appsettings.json
+++ b/backend/ClimbConnect.API/appsettings.json
@@ -9,7 +9,7 @@
     }
   },
   "Jwt": {
-    "Key": "ClimbConnect-SuperSecret-Key-MinLength-32-Chars!",
+    "Key": "CHANGE_ME_SET_VIA_ENV_VAR_JWT__KEY_MIN_32_CHARS",
     "Issuer": "climbconnect-api",
     "Audience": "climbconnect-ui",
     "ExpiryHours": 24
@@ -21,5 +21,8 @@
     "VerifyTokenAudience": false,
     "PublicClient": true
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:4200" ]
+  }
 }


### PR DESCRIPTION
## Was wurde gefixt?

- **JWT-Secret** nicht mehr im Repository: `appsettings.json` enthält jetzt nur einen Platzhalter, der Dev-Key liegt in `appsettings.Development.json`, Produktion muss `Jwt__Key` per Umgebungsvariable setzen
- **Swagger** ist jetzt nur noch in Development aktiv – in Produktion nicht mehr öffentlich erreichbar
- **Reports-Endpoints** hatten keine Authentifizierung: `GET /api/reports` und `PUT /api/reports/{id}/status` erfordern jetzt die Admin-Rolle
- **CORS** war komplett offen (`AllowAnyOrigin`): erlaubte Origins werden jetzt aus `appsettings.json` gelesen (`Cors:AllowedOrigins`)

## Geänderte Dateien

- `.gitignore` – Hinweis auf Secrets ergänzt
- `appsettings.json` – JWT-Key als Platzhalter, CORS-Konfiguration
- `appsettings.Development.json` – Dev-JWT-Key, Dev-CORS-Origins
- `Program.cs` – Swagger-Guard, CORS-Policy, Reports-Auth

## Test

- `dotnet build` erfolgreich, 0 Fehler, 0 Warnungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)