### PR TITLE
fix: Kleinere Bugs und Doku-Fehler behoben

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,8 @@ Lies diese Dateien bevor du mit der Implementierung beginnst:
 
 ## Stack
 
-- Backend: .NET 8 Minimal API, C#, EF Core, PostgreSQL
-- Auth: Keycloak (Rollen: Admin, User)
+- Backend: .NET 8 Minimal API, C#, EF Core, SQLite
+- Auth: JWT (eigenes System), Keycloak vorbereitet aber noch nicht aktiv
 - Frontend: Angular (anderer Kollege zuständig)
 - CI/CD: GitHub Actions
 - Grades: intern französische Skala, Konversion zu UIAA und Amerikanisch

--- a/backend/ClimbConnect.API/Models/User.cs
+++ b/backend/ClimbConnect.API/Models/User.cs
@@ -6,7 +6,7 @@ public class User
     public string Email { get; set; } = string.Empty;
     public string Username { get; set; } = string.Empty;
     public string PasswordHash { get; set; } = string.Empty;
-    public string Role { get; set; } = "User";    // "User" | "Admin"
+    public string Role { get; set; } = "user";    // "user" | "admin"
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
     public ICollection<Progress> Progresses { get; set; } = [];

--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -643,12 +643,15 @@ app.MapDelete("/api/progress/{id:int}", async (int id, ClaimsPrincipal user, App
 // --------------------
 // APPOINTMENTS
 // --------------------
-app.MapGet("/api/areas/{id:int}/appointments", async (int id, AppDbContext db) =>
+app.MapGet("/api/areas/{id:int}/appointments", async (int id, bool? all, AppDbContext db) =>
 {
     if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
 
+    // Standardmäßig nur zukünftige Termine; mit ?all=true auch vergangene
+    var cutoff = (all == true) ? DateTime.MinValue : DateTime.UtcNow;
+
     var appointments = await db.Appointments
-        .Where(a => a.AreaId == id)
+        .Where(a => a.AreaId == id && a.Date >= cutoff)
         .Include(a => a.AppointmentUsers)
         .OrderBy(a => a.Date)
         .ToListAsync();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "5004:8080"
     environment:
-      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_ENVIRONMENT=Production
       - ConnectionStrings__DefaultConnection=Data Source=/app/Data/ClimbConnect.db;
       - Jwt__Key=ClimbConnect-SuperSecret-Key-MinLength-32-Chars!
       - Jwt__Issuer=climbconnect-api


### PR DESCRIPTION
## Änderungen

**docker-compose.yml**
`ASPNETCORE_ENVIRONMENT=Development` → `Production`: In Development werden Stack-Traces an den Client gesendet — das darf in der produktiven Umgebung nicht passieren.

**User.cs**
`Role` Default-Wert von `"User"` auf `"user"` korrigiert. Die Auth-Policies prüfen Kleinbuchstaben (`RequireRole("user", "admin")`), der Model-Default war inkonsistent und hätte bei direkter DB-Manipulation zu Authentifizierungsfehlern geführt.

**Program.cs — GET /api/areas/{id}/appointments**
Zeigt jetzt standardmäßig nur zukünftige Termine. Mit `?all=true` können auch vergangene abgerufen werden (z.B. für eine Termin-History).

**CLAUDE.md**
Stack-Beschreibung korrigiert: SQLite statt PostgreSQL, JWT statt Keycloak (Keycloak ist vorbereitet aber noch nicht aktiv).

## Test
- `dotnet build` erfolgreich, 0 Fehler, 0 Warnungen

🤖 Generated with [Claude Code](https://claude.com/claude-code)