### PR TITLE
fix: Frontend-Konfiguration und Auth-Bugs behoben

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,6 @@
     "@angular/platform-browser": "^20.3.0",
     "@angular/router": "^20.3.0",
     "bootstrap": "^5.3.8",
-    "keycloak-angular": "^20.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -6,8 +6,9 @@ import { ForbiddenComponent } from './forbidden/forbidden.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
 import { AreasPageComponent } from './features/areas/areas-page.component';
 import { LoginComponent } from './features/auth/login/login.component';
-import { canActivateAuthRole } from './guards/auth-role.guard';
 import { RegisterComponent } from './features/auth/register/register.component';
+import { canActivateAuthRole } from './guards/auth-role.guard';
+
 export const routes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
 
@@ -15,9 +16,9 @@ export const routes: Routes = [
 
   { path: 'areas', component: AreasPageComponent },
 
-  { path: 'admin', component: AdminComponent },
+  { path: 'admin', component: AdminComponent, canActivate: [canActivateAuthRole] },
 
-  { path: 'profile', component: UserProfileComponent },
+  { path: 'profile', component: UserProfileComponent, canActivate: [canActivateAuthRole] },
 
   { path: 'forbidden', component: ForbiddenComponent },
   { path: 'login', component: LoginComponent },

--- a/frontend/src/app/features/auth/login/login.component.ts
+++ b/frontend/src/app/features/auth/login/login.component.ts
@@ -25,10 +25,7 @@ export class LoginComponent {
     }
 
     this.authService.login(email, password).subscribe({
-      next: (response: any) => {
-
-        localStorage.setItem('token', response.token);
-
+      next: () => {
         this.router.navigate(['/home']);
       },
 

--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -12,10 +12,10 @@ export class RegisterComponent {
 
   errorMessage = '';
 
-constructor(
-  private authService: AuthService,
-  private router: Router
-) {}
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
 
   register(
     username: string,
@@ -23,58 +23,33 @@ constructor(
     password: string,
     confirmPassword: string
   ): void {
-      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-  if (!emailPattern.test(email)) {
-    this.errorMessage = 'Bitte eine gültige E-Mail-Adresse eingeben';
-    return;
-  }
+    if (!emailPattern.test(email)) {
+      this.errorMessage = 'Bitte eine gültige E-Mail-Adresse eingeben';
+      return;
+    }
     if (password.length < 8) {
-    this.errorMessage = 'Passwort muss mindestens 8 Zeichen haben';
-    return;
-  }
-
+      this.errorMessage = 'Passwort muss mindestens 8 Zeichen haben';
+      return;
+    }
     if (password !== confirmPassword) {
       this.errorMessage = 'Passwörter stimmen nicht überein';
       return;
     }
 
-    const user = {
-      username,
-      email,
-      password
-    };
-
-   this.authService.register(user).subscribe({
-  next: (response: any) => {
-
-  localStorage.setItem('token', response.token);
-
-  console.log('Registrierung erfolgreich', response);
-
-  this.router.navigate(['/home']);
-
-},
-  error: (error: any) => {
-
-  if (error.status === 409) {
-
-    if (error.error?.message?.includes('email')) {
-      this.errorMessage = 'E-Mail bereits vergeben';
-    }
-    else if (error.error?.message?.includes('username')) {
-      this.errorMessage = 'Username bereits vergeben';
-    }
-    else {
-      this.errorMessage = 'Benutzer existiert bereits';
-    }
-
-  } else {
-    this.errorMessage = 'Registrierung fehlgeschlagen';
-  }
-
-  console.error(error);
-}
-});
+    this.authService.register({ username, email, password }).subscribe({
+      next: () => {
+        this.router.navigate(['/home']);
+      },
+      error: (error: any) => {
+        if (error.status === 409) {
+          this.errorMessage = error.error?.error ?? 'Benutzer existiert bereits';
+        } else {
+          this.errorMessage = 'Registrierung fehlgeschlagen';
+        }
+        console.error(error);
+      }
+    });
   }
 }

--- a/frontend/src/app/guards/auth-role.guard.ts
+++ b/frontend/src/app/guards/auth-role.guard.ts
@@ -1,5 +1,15 @@
-import { CanActivateFn } from '@angular/router';
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { AuthService } from '../../services/auth.service';
 
 export const canActivateAuthRole: CanActivateFn = () => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  if (!authService.isAuthenticated()) {
+    router.navigate(['/login']);
+    return false;
+  }
+
   return true;
 };

--- a/frontend/src/app/menu/menu.component.ts
+++ b/frontend/src/app/menu/menu.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
+import { AuthService } from '../../services/auth.service';
 
 @Component({
   selector: 'app-menu',
@@ -10,18 +11,17 @@ import { RouterModule } from '@angular/router';
 })
 export class MenuComponent {
 
-  authenticated = false;
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
 
-  constructor() {
-    this.authenticated = !!localStorage.getItem('token');
-  }
-
-  login(): void {
-    console.log('Navigate to login page');
+  get authenticated(): boolean {
+    return this.authService.isAuthenticated();
   }
 
   logout(): void {
-    localStorage.removeItem('token');
-    this.authenticated = false;
+    this.authService.logout();
+    this.router.navigate(['/login']);
   }
 }

--- a/frontend/src/environments/environment.development.ts
+++ b/frontend/src/environments/environment.development.ts
@@ -1,5 +1,4 @@
 export const environment = {
   production: false,
-//  apiUrl: '/api'        // leocloud (url see proxy.conf.json) => we use proxy in development to avoid CORS issues
-  apiUrl: 'https://localhost:5124' // local backend for development
+  apiUrl: 'http://localhost:5004'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://h-aitenbichler.cloud.htl-leonding.ac.at/demosypapi'
+  apiUrl: 'https://r-lehner.cloud.htl-leonding.ac.at/climbconnectapi'
 };

--- a/frontend/src/models/user.model.ts
+++ b/frontend/src/models/user.model.ts
@@ -1,5 +1,14 @@
 export interface User {
-  name: string;
-  email?: string;
-  username?: string;
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  id: number;
+  username: string;
+  email: string;
+  role: string;
 }

--- a/frontend/src/proxy.conf.json
+++ b/frontend/src/proxy.conf.json
@@ -1,11 +1,8 @@
 {
   "/api": {
-    "target": "https://h-aitenbichler.cloud.htl-leonding.ac.at/demosypapi",
+    "target": "http://localhost:5004",
     "secure": false,
     "changeOrigin": true,
-    "pathRewrite": {
-     "^/api": ""  
-    },
     "logLevel": "debug"
   }
 }

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -1,24 +1,19 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
+import { environment } from '../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
 
-  private apiUrl = 'http://localhost:8080/api/auth';
+  private apiUrl = `${environment.apiUrl}/api/auth`;
 
   constructor(private http: HttpClient) {}
 
   login(email: string, password: string): Observable<any> {
-    return this.http.post<any>(
-      `${this.apiUrl}/login`,
-      {
-        email,
-        password
-      }
-    ).pipe(
+    return this.http.post<any>(`${this.apiUrl}/login`, { email, password }).pipe(
       tap(response => {
         if (response.token) {
           localStorage.setItem('token', response.token);
@@ -28,9 +23,12 @@ export class AuthService {
   }
 
   register(user: any): Observable<any> {
-    return this.http.post(
-      `${this.apiUrl}/register`,
-      user
+    return this.http.post<any>(`${this.apiUrl}/register`, user).pipe(
+      tap(response => {
+        if (response.token) {
+          localStorage.setItem('token', response.token);
+        }
+      })
     );
   }
 


### PR DESCRIPTION
## Summary

Behebt alle kritischen Blocker und Bugs die das Frontend-Team blockiert haben.

**Falsche URLs (Demo-Projekt → ClimbConnect)**
- `proxy.conf.json`: zeigt jetzt auf `http://localhost:5004` + `pathRewrite` entfernt (hat `/api`-Prefix gelöscht)
- `environment.ts`: Production-URL auf `https://r-lehner.cloud.htl-leonding.ac.at/climbconnectapi` korrigiert
- `environment.development.ts`: Port 5004 statt 5124, HTTP statt HTTPS

**Keycloak entfernt (closes #135)**
- `keycloak-angular` aus `package.json` entfernt

**Auth-Service**
- Hardcoded URL durch `environment.apiUrl` ersetzt
- `register()` speichert Token jetzt auch (wie `login()`)

**Auth Guard**
- War leer (immer `true`) — leitet jetzt bei fehlender Auth auf `/login` um
- Guard auf `/profile` und `/admin` angewendet

**Menu**
- `authenticated` war nur im Constructor gesetzt (nicht reaktiv)
- Jetzt als Getter über `AuthService.isAuthenticated()` — aktualisiert sich bei Login/Logout
- `logout()` navigiert nach `/login`

**Bugs**
- `login.component.ts` + `register.component.ts`: Token wurde doppelt in localStorage gespeichert
- `register.component.ts`: Fehlerfeld war `error.message`, Backend gibt `error.error` zurück
- `user.model.ts`: `id` und `role` ergänzt, `AuthResponse` Interface hinzugefügt

## Test plan

- [ ] `npm install` — kein Fehler wegen fehlenden Paketen
- [ ] `ng build` — kompiliert ohne Fehler
- [ ] Login mit `user@climbconnect.at` / `User1234!` → Token in localStorage, Weiterleitung zu `/home`
- [ ] Nach Login: Menü zeigt "eingeloggt"-Status
- [ ] Logout → Token entfernt, Weiterleitung zu `/login`
- [ ] `/profile` ohne Login aufrufen → Weiterleitung zu `/login`
- [ ] Registrierung mit bereits vorhandener E-Mail → Fehlermeldung "E-Mail bereits vergeben"