### PR TITLE
US-05 Area Details anzeigen #87

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -26,7 +26,7 @@ export const routes: Routes = [
   },
 
   {
-    path: 'profile',
+    path: 'profile',  
     component: UserProfileComponent,
     canActivate: [canActivateAuthRole]
   },

--- a/frontend/src/app/features/areas/area-detail.component.css
+++ b/frontend/src/app/features/areas/area-detail.component.css
@@ -4,33 +4,203 @@
 
 .back-link {
   display: inline-block;
-  margin-bottom: 20px;
-  text-decoration: none;
+  margin-bottom: 24px;
   color: #1864ab;
-  font-weight: 600;
+  text-decoration: none;
+  font-weight: 700;
 }
 
-.area-detail h1 {
-  margin: 0 0 12px;
-  font-size: 34px;
+.area-header {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 28px;
+  margin-bottom: 32px;
+  background: white;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.10);
+}
+
+.area-image {
+  height: 260px;
+  background: #dfe3e6;
+}
+
+.area-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.area-image-placeholder {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 72px;
+  font-weight: bold;
+  color: #555;
+}
+
+.area-info {
+  padding: 28px 28px 28px 0;
+}
+
+.area-info h1 {
+  margin: 0 0 10px;
+  font-size: 36px;
 }
 
 .location {
+  margin: 0 0 14px;
   color: #555;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .description {
-  max-width: 700px;
+  margin: 0;
+  max-width: 800px;
+  color: #555;
   line-height: 1.5;
 }
 
-.hint {
-  margin-top: 24px;
-  color: #777;
-  font-style: italic;
+.content-grid {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 24px;
 }
 
-.error {
+.detail-section {
+  background: white;
+  border-radius: 16px;
+  padding: 22px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  margin-bottom: 24px;
+}
+
+.detail-section h2 {
+  margin-top: 0;
+}
+
+.sector-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.sector-card {
+  border: 1px solid #e1e5e8;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.sector-header {
+  width: 100%;
+  padding: 16px;
+  border: none;
+  background: #f8f9fa;
+  display: flex;
+  justify-content: space-between;
+  font-size: 17px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.sector-description {
+  padding: 0 16px;
+  color: #666;
+}
+
+.routes-box {
+  padding: 16px;
+}
+
+.routes-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.routes-table th,
+.routes-table td {
+  padding: 10px;
+  border-bottom: 1px solid #e9ecef;
+  text-align: left;
+}
+
+.routes-table th {
+  color: #555;
+  font-size: 14px;
+}
+
+.appointment-list,
+.comment-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.appointment-card,
+.comment-card {
+  padding: 14px;
+  border-radius: 12px;
+  background: #f8f9fa;
+}
+
+.appointment-card h3 {
+  margin: 0 0 8px;
+}
+
+.comments-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.comment-button {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: #222;
+  color: white;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.comment-author {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.comment-author img {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
+.empty-text {
+  color: #777;
+}
+
+.loading-box,
+.error-box {
+  padding: 28px;
+  background: #f8f9fa;
+  border-radius: 12px;
+}
+
+.error-box {
   color: #c92a2a;
+}
+
+@media (max-width: 900px) {
+  .area-header,
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .area-info {
+    padding: 22px;
+  }
 }

--- a/frontend/src/app/features/areas/area-detail.component.html
+++ b/frontend/src/app/features/areas/area-detail.component.html
@@ -6,27 +6,208 @@
 
   @if (loading) {
 
-    <p>Gebiet wird geladen...</p>
+    <div class="loading-box">
+      Gebiet wird geladen...
+    </div>
 
   } @else if (errorMessage) {
 
-    <p class="error">{{ errorMessage }}</p>
+    <div class="error-box">
+      {{ errorMessage }}
+    </div>
 
   } @else if (area) {
 
-    <h1>{{ area.name }}</h1>
+    <div class="area-header">
 
-    <p class="location">
-      {{ area.location || 'Kein Standort angegeben' }}
-    </p>
+      <div class="area-image">
+        @if (area.imageUrl) {
+          <img [src]="area.imageUrl" [alt]="area.name">
+        } @else {
+          <div class="area-image-placeholder">
+            {{ area.name.charAt(0) }}
+          </div>
+        }
+      </div>
 
-    <p class="description">
-      {{ area.description || 'Keine Beschreibung vorhanden.' }}
-    </p>
+      <div class="area-info">
+        <h1>{{ area.name }}</h1>
 
-    <p class="hint">
-      Sektoren werden im nächsten Issue angezeigt.
-    </p>
+        <p class="location">
+          {{ area.location || 'Kein Standort angegeben' }}
+        </p>
+
+        <p class="description">
+          {{ area.description || 'Keine Beschreibung vorhanden.' }}
+        </p>
+      </div>
+
+    </div>
+
+    <div class="content-grid">
+
+      <section class="detail-section">
+        <h2>Sektoren & Routen</h2>
+
+        @if (sectors.length === 0) {
+
+          <p class="empty-text">Keine Sektoren vorhanden.</p>
+
+        } @else {
+
+          <div class="sector-list">
+
+            @for (sector of sectors; track sector.id) {
+
+              <div class="sector-card">
+
+                <button class="sector-header" type="button" (click)="toggleSector(sector)">
+                  <span>{{ sector.name }}</span>
+                  <span>{{ sector.expanded ? '▲' : '▼' }}</span>
+                </button>
+
+                @if (sector.description) {
+                  <p class="sector-description">
+                    {{ sector.description }}
+                  </p>
+                }
+
+                @if (sector.expanded) {
+
+                  <div class="routes-box">
+
+                    @if (sector.loadingRoutes) {
+
+                      <p>Routen werden geladen...</p>
+
+                    } @else if (sector.routes.length === 0) {
+
+                      <p class="empty-text">Keine Routen vorhanden.</p>
+
+                    } @else {
+
+                      <table class="routes-table">
+                        <thead>
+                          <tr>
+                            <th>Name</th>
+                            <th>Grad</th>
+                            <th>Länge</th>
+                            <th>Stil</th>
+                          </tr>
+                        </thead>
+
+                        <tbody>
+                          @for (route of sector.routes; track route.id) {
+                            <tr>
+                              <td>{{ route.name }}</td>
+                              <td>{{ route.grade || '-' }}</td>
+                              <td>
+                                @if (route.length) {
+                                  {{ route.length }} m
+                                } @else {
+                                  -
+                                }
+                              </td>
+                              <td>{{ route.style || '-' }}</td>
+                            </tr>
+                          }
+                        </tbody>
+                      </table>
+
+                    }
+
+                  </div>
+
+                }
+
+              </div>
+
+            }
+
+          </div>
+
+        }
+
+      </section>
+
+      <aside class="side-column">
+
+        <section class="detail-section">
+          <h2>Kommende Termine</h2>
+
+          @if (appointments.length === 0) {
+
+            <p class="empty-text">Keine Termine vorhanden.</p>
+
+          } @else {
+
+            <div class="appointment-list">
+              @for (appointment of appointments; track appointment.id) {
+                <div class="appointment-card">
+                  <h3>{{ appointment.title }}</h3>
+
+                  <p>
+                    {{ appointment.date || 'Kein Datum angegeben' }}
+                  </p>
+
+                  <p>
+                    Teilnehmer: {{ appointment.participantCount ?? 0 }}
+                  </p>
+                </div>
+              }
+            </div>
+
+          }
+
+        </section>
+
+        <section class="detail-section">
+          <div class="comments-header">
+            <h2>Kommentare</h2>
+
+            @if (isLoggedIn()) {
+              <button type="button" class="comment-button">
+                Kommentar schreiben
+              </button>
+            }
+          </div>
+
+          @if (comments.length === 0) {
+
+            <p class="empty-text">Keine Kommentare vorhanden.</p>
+
+          } @else {
+
+            <div class="comment-list">
+              @for (comment of comments; track comment.id) {
+                <div class="comment-card">
+
+                  <div class="comment-author">
+
+                    @if (comment.authorPhotoUrl) {
+                      <img [src]="comment.authorPhotoUrl" [alt]="comment.authorName || 'User'">
+                    }
+
+                    <strong>{{ comment.authorName || 'Unbekannter User' }}</strong>
+                  </div>
+
+                  <p>{{ comment.text }}</p>
+
+                  @if (comment.createdAt) {
+                    <small>{{ comment.createdAt }}</small>
+                  }
+
+                </div>
+              }
+            </div>
+
+          }
+
+        </section>
+
+      </aside>
+
+    </div>
 
   }
 

--- a/frontend/src/app/features/areas/area-detail.component.ts
+++ b/frontend/src/app/features/areas/area-detail.component.ts
@@ -1,11 +1,26 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { Area, AreasService } from '../../../services/areas.service';
+import { CommonModule } from '@angular/common';
+import {
+  Area,
+  AreaComment,
+  Appointment,
+  AreasService,
+  ClimbingRoute,
+  Sector
+} from '../../../services/areas.service';
+import { AuthService } from '../../../services/auth.service';
+
+interface SectorWithRoutes extends Sector {
+  expanded: boolean;
+  loadingRoutes: boolean;
+  routes: ClimbingRoute[];
+}
 
 @Component({
   selector: 'app-area-detail',
   standalone: true,
-  imports: [RouterLink],
+  imports: [CommonModule, RouterLink],
   templateUrl: './area-detail.component.html',
   styleUrl: './area-detail.component.css'
 })
@@ -13,8 +28,13 @@ export class AreaDetailComponent implements OnInit {
 
   private route = inject(ActivatedRoute);
   private areasService = inject(AreasService);
+  private authService = inject(AuthService);
 
   area?: Area;
+  sectors: SectorWithRoutes[] = [];
+  appointments: Appointment[] = [];
+  comments: AreaComment[] = [];
+
   loading = true;
   errorMessage = '';
 
@@ -27,7 +47,14 @@ export class AreaDetailComponent implements OnInit {
       return;
     }
 
-    this.areasService.getAreaById(id).subscribe({
+    this.loadAreaDetails(id);
+  }
+
+  loadAreaDetails(areaId: number): void {
+    this.loading = true;
+    this.errorMessage = '';
+
+    this.areasService.getAreaById(areaId).subscribe({
       next: (area) => {
         this.area = area;
         this.loading = false;
@@ -37,5 +64,78 @@ export class AreaDetailComponent implements OnInit {
         this.loading = false;
       }
     });
+
+    this.areasService.getSectorsByArea(areaId).subscribe({
+      next: (sectors) => {
+        this.sectors = sectors.map(sector => ({
+          ...sector,
+          expanded: false,
+          loadingRoutes: false,
+          routes: []
+        }));
+      },
+      error: () => {
+        console.error('Sektoren konnten nicht geladen werden.');
+      }
+    });
+
+    this.areasService.getAppointmentsByArea(areaId).subscribe({
+      next: (appointments) => {
+        this.appointments = appointments;
+      },
+      error: () => {
+        console.error('Termine konnten nicht geladen werden.');
+      }
+    });
+
+    this.areasService.getCommentsByArea(areaId).subscribe({
+      next: (comments) => {
+        this.comments = comments;
+      },
+      error: () => {
+        console.error('Kommentare konnten nicht geladen werden.');
+      }
+    });
+  }
+
+  toggleSector(sector: SectorWithRoutes): void {
+    sector.expanded = !sector.expanded;
+
+    if (sector.expanded && sector.routes.length === 0) {
+      this.loadRoutesForSector(sector);
+    }
+  }
+
+  loadRoutesForSector(sector: SectorWithRoutes): void {
+    sector.loadingRoutes = true;
+
+    const scale = this.getPreferredGradeScale();
+
+    this.areasService.getRoutesBySector(sector.id, scale).subscribe({
+      next: (routes) => {
+        sector.routes = routes;
+        sector.loadingRoutes = false;
+      },
+      error: () => {
+        sector.loadingRoutes = false;
+        console.error('Routen konnten nicht geladen werden.');
+      }
+    });
+  }
+
+  getPreferredGradeScale(): string {
+    const token = this.authService.getToken();
+
+    if (!token) {
+      return 'french';
+    }
+
+    const payload = this.authService.getRole();
+
+    return payload === 'admin' ? 'french' : 'french';
+  }
+
+  isLoggedIn(): boolean {
+    return this.authService.isAuthenticated();
   }
 }

--- a/frontend/src/services/areas.service.ts
+++ b/frontend/src/services/areas.service.ts
@@ -10,8 +10,35 @@ export interface Area {
   description?: string | null;
   imageUrl?: string | null;
   todayVisitors?: number;
-  todayAppointments?: number;
-  createdAtUtc?: string;
+}
+
+export interface Sector {
+  id: number;
+  name: string;
+  description?: string | null;
+}
+
+export interface ClimbingRoute {
+  id: number;
+  name: string;
+  grade?: string | null;
+  length?: number | null;
+  style?: string | null;
+}
+
+export interface Appointment {
+  id: number;
+  title: string;
+  date?: string | null;
+  participantCount?: number;
+}
+
+export interface AreaComment {
+  id: number;
+  text: string;
+  authorName?: string | null;
+  authorPhotoUrl?: string | null;
+  createdAt?: string | null;
 }
 
 @Injectable({
@@ -19,15 +46,31 @@ export interface Area {
 })
 export class AreasService {
 
-  private apiUrl = `${environment.apiUrl}/api/areas`;
+  private apiUrl = `${environment.apiUrl}/api`;
 
   constructor(private http: HttpClient) {}
 
   getAreas(): Observable<Area[]> {
-    return this.http.get<Area[]>(this.apiUrl);
+    return this.http.get<Area[]>(`${this.apiUrl}/areas`);
   }
 
   getAreaById(id: number): Observable<Area> {
-    return this.http.get<Area>(`${this.apiUrl}/${id}`);
+    return this.http.get<Area>(`${this.apiUrl}/areas/${id}`);
+  }
+
+  getSectorsByArea(areaId: number): Observable<Sector[]> {
+    return this.http.get<Sector[]>(`${this.apiUrl}/areas/${areaId}/sectors`);
+  }
+
+  getRoutesBySector(sectorId: number, scale: string): Observable<ClimbingRoute[]> {
+    return this.http.get<ClimbingRoute[]>(`${this.apiUrl}/sectors/${sectorId}/routes?scale=${scale}`);
+  }
+
+  getAppointmentsByArea(areaId: number): Observable<Appointment[]> {
+    return this.http.get<Appointment[]>(`${this.apiUrl}/areas/${areaId}/appointments`);
+  }
+
+  getCommentsByArea(areaId: number): Observable<AreaComment[]> {
+    return this.http.get<AreaComment[]>(`${this.apiUrl}/areas/${areaId}/comments`);
   }
 }


### PR DESCRIPTION
## Changes

- Added area detail page for /areas/{id}
- Shows area header with name, location, description and image
- Loads sectors for selected area
- Added expandable sector list
- Loads routes for each sector with grade, length and style
- Loads upcoming appointments
- Loads comments
- Shows comment button only for logged-in users

## Testing

- Backend started on http://localhost:5004
- Frontend started on http://localhost:4200
- /areas loads area cards
- Clicking an area opens /areas/{id}
- Sectors can be expanded
- Routes are displayed with grade, length and style
- npm run build succeeds

Closes #87