### PR TITLE
US-08 Klettersession erstellen #90

### DIFF
--- a/backend/ClimbConnect.API/Program.cs
+++ b/backend/ClimbConnect.API/Program.cs
@@ -743,59 +743,44 @@ app.MapPost("/api/areas/{id:int}/appointments", async (int id, AppointmentCreate
 {
     if (!int.TryParse(user.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
         return Results.Unauthorized();
-    if (!await db.Areas.AnyAsync(a => a.Id == id)) return Results.NotFound();
+
+    var areaExists = await db.Areas.AnyAsync(a => a.Id == id);
+    if (!areaExists)
+        return Results.NotFound();
+
+    var currentUser = await db.Users.FindAsync(userId);
+    if (currentUser is null)
+        return Results.Unauthorized();
+
     if (string.IsNullOrWhiteSpace(dto.Title))
         return Results.BadRequest(new { error = "Titel ist erforderlich" });
+
+    if (dto.MinParticipants.HasValue && dto.MaxParticipants.HasValue &&
+        dto.MinParticipants.Value > dto.MaxParticipants.Value)
+        return Results.BadRequest(new { error = "Minimale Teilnehmerzahl darf nicht größer als maximale Teilnehmerzahl sein" });
 
     var appointment = new Appointment
     {
         AreaId          = id,
         CreatedByUserId = userId,
+        CreatedBy       = currentUser,
         Title           = dto.Title.Trim(),
         Date            = dto.Date,
-        MeetingPoint    = string.IsNullOrWhiteSpace(dto.MeetingPoint)  ? null : dto.MeetingPoint.Trim(),
-        Description     = string.IsNullOrWhiteSpace(dto.Description)   ? null : dto.Description.Trim(),
+        MeetingPoint    = string.IsNullOrWhiteSpace(dto.MeetingPoint) ? null : dto.MeetingPoint.Trim(),
+        Description     = string.IsNullOrWhiteSpace(dto.Description) ? null : dto.Description.Trim(),
         MinParticipants = dto.MinParticipants,
         MaxParticipants = dto.MaxParticipants
     };
+
     db.Appointments.Add(appointment);
     await db.SaveChangesAsync();
+
     return Results.Created($"/api/appointments/{appointment.Id}", appointment);
 })
 .WithName("CreateAppointment")
 .WithTags("Appointments")
 .RequireAuthorization("User");
 
-app.MapPost("/api/appointments/{id:int}/subscribe", async (int id, AppointmentSubscribeDto dto, ClaimsPrincipal user, AppDbContext db) =>
-{
-    if (!int.TryParse(user.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
-        return Results.Unauthorized();
-
-    var appointment = await db.Appointments
-        .Include(a => a.AppointmentUsers)
-        .FirstOrDefaultAsync(a => a.Id == id);
-    if (appointment is null) return Results.NotFound();
-
-    if (appointment.AppointmentUsers.Any(au => au.UserId == userId))
-        return Results.Conflict(new { error = "Bereits angemeldet" });
-
-    if (appointment.MaxParticipants.HasValue &&
-        appointment.AppointmentUsers.Count >= appointment.MaxParticipants.Value)
-        return Results.Conflict(new { error = "Maximale Teilnehmerzahl erreicht" });
-
-    var subscription = new AppointmentUser
-    {
-        AppointmentId = id,
-        UserId        = userId,
-        Comment       = string.IsNullOrWhiteSpace(dto.Comment) ? null : dto.Comment.Trim()
-    };
-    db.AppointmentUsers.Add(subscription);
-    await db.SaveChangesAsync();
-    return Results.Created($"/api/appointments/{id}/subscribe", subscription);
-})
-.WithName("SubscribeToAppointment")
-.WithTags("Appointments")
-.RequireAuthorization("User");
 
 app.MapDelete("/api/appointments/{id:int}/subscribe", async (int id, ClaimsPrincipal user, AppDbContext db) =>
 {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -9,13 +9,22 @@ import { LoginComponent } from './features/auth/login/login.component';
 import { RegisterComponent } from './features/auth/register/register.component';
 import { canActivateAuthRole } from './guards/auth-role.guard';
 import { AreaDetailComponent } from './features/areas/area-detail.component';
+import { AppointmentFormComponent } from './features/appointments/appointment-form.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
 
   { path: 'home', component: HomeComponent },
 
+  
   { path: 'areas', component: AreasPageComponent },
+
+  {
+  path: 'areas/:id/appointments/new',
+  component: AppointmentFormComponent,
+  canActivate: [canActivateAuthRole]
+},
+
   { path: 'areas/:id', component: AreaDetailComponent },
 
   {

--- a/frontend/src/app/features/appointments/appointment-form.component.css
+++ b/frontend/src/app/features/appointments/appointment-form.component.css
@@ -1,0 +1,164 @@
+.appointment-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 24px;
+  color: #1864ab;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.appointment-card {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.10);
+  border: 1px solid #e5e7eb;
+}
+
+.appointment-header {
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #f97316;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.appointment-header h1 {
+  margin: 0;
+  font-size: 34px;
+  color: #111827;
+}
+
+.appointment-header p {
+  margin: 10px 0 0;
+  color: #6b7280;
+  line-height: 1.5;
+}
+
+.appointment-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+label {
+  color: #374151;
+  font-weight: 700;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: #f9fafb;
+  color: #111827;
+  outline: none;
+}
+
+textarea {
+  min-height: 130px;
+  resize: vertical;
+}
+
+input:focus,
+textarea:focus {
+  border-color: #f97316;
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.16);
+  background: #ffffff;
+}
+
+.error-box {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #fef2f2;
+  color: #b91c1c;
+  border: 1px solid #fecaca;
+  font-weight: 700;
+}
+
+.button-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.cancel-button,
+.submit-button {
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 800;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.cancel-button {
+  background: #f3f4f6;
+  color: #374151;
+  border: 1px solid #d1d5db;
+}
+
+.submit-button {
+  background: #f97316;
+  color: white;
+  border: none;
+}
+
+.submit-button:hover {
+  background: #ea580c;
+}
+
+.submit-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+@media (max-width: 700px) {
+  .appointment-page {
+    padding: 24px 18px;
+  }
+
+  .appointment-card {
+    padding: 24px;
+  }
+
+  .appointment-form {
+    grid-template-columns: 1fr;
+  }
+
+  .appointment-header h1 {
+    font-size: 28px;
+  }
+
+  .button-row {
+    flex-direction: column;
+  }
+
+  .cancel-button,
+  .submit-button {
+    text-align: center;
+    width: 100%;
+  }
+}

--- a/frontend/src/app/features/appointments/appointment-form.component.html
+++ b/frontend/src/app/features/appointments/appointment-form.component.html
@@ -1,0 +1,109 @@
+<section class="appointment-page">
+
+  <a [routerLink]="['/areas', areaId]" class="back-link">
+    ← Zurück zum Gebiet
+  </a>
+
+  <div class="appointment-card">
+
+    <div class="appointment-header">
+      <p class="eyebrow">ClimbConnect</p>
+      <h1>Klettersession erstellen</h1>
+      <p>Erstelle einen Termin, damit andere Benutzer daran teilnehmen können.</p>
+    </div>
+
+    <form class="appointment-form" (ngSubmit)="createAppointment()">
+
+      <div class="form-field full-width">
+        <label for="title">Titel</label>
+        <input
+          id="title"
+          type="text"
+          name="title"
+          [(ngModel)]="form.title"
+          placeholder="z. B. Feierabend-Klettern">
+      </div>
+
+      <div class="form-field">
+        <label for="date">Datum</label>
+        <input
+          id="date"
+          type="date"
+          name="date"
+          [(ngModel)]="form.date">
+      </div>
+
+      <div class="form-field">
+        <label for="time">Uhrzeit</label>
+        <input
+          id="time"
+          type="time"
+          name="time"
+          [(ngModel)]="form.time">
+      </div>
+
+      <div class="form-field full-width">
+        <label for="meetingPoint">Treffpunkt</label>
+        <input
+          id="meetingPoint"
+          type="text"
+          name="meetingPoint"
+          [(ngModel)]="form.meetingPoint"
+          placeholder="z. B. Parkplatz beim Einstieg">
+      </div>
+
+      <div class="form-field full-width">
+        <label for="description">Beschreibung</label>
+        <textarea
+          id="description"
+          name="description"
+          [(ngModel)]="form.description"
+          placeholder="Zusätzliche Infos zur Session...">
+        </textarea>
+      </div>
+
+      <div class="form-field">
+        <label for="minParticipants">Min. Teilnehmer</label>
+        <input
+          id="minParticipants"
+          type="number"
+          name="minParticipants"
+          min="1"
+          [(ngModel)]="form.minParticipants">
+      </div>
+
+      <div class="form-field">
+        <label for="maxParticipants">Max. Teilnehmer</label>
+        <input
+          id="maxParticipants"
+          type="number"
+          name="maxParticipants"
+          min="1"
+          [(ngModel)]="form.maxParticipants">
+      </div>
+
+      @if (errorMessage) {
+        <div class="error-box full-width">
+          {{ errorMessage }}
+        </div>
+      }
+
+      <div class="button-row full-width">
+        <a [routerLink]="['/areas', areaId]" class="cancel-button">
+          Abbrechen
+        </a>
+
+        <button type="submit" class="submit-button" [disabled]="submitting">
+          @if (submitting) {
+            Wird erstellt...
+          } @else {
+            Klettersession erstellen
+          }
+        </button>
+      </div>
+
+    </form>
+
+  </div>
+
+</section>

--- a/frontend/src/app/features/appointments/appointment-form.component.ts
+++ b/frontend/src/app/features/appointments/appointment-form.component.ts
@@ -1,0 +1,88 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { AreasService, AppointmentCreateRequest } from '../../../services/areas.service';
+
+@Component({
+  selector: 'app-appointment-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './appointment-form.component.html',
+  styleUrl: './appointment-form.component.css'
+})
+export class AppointmentFormComponent {
+
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private areasService = inject(AreasService);
+
+  areaId = Number(this.route.snapshot.paramMap.get('id'));
+
+  submitting = false;
+  errorMessage = '';
+
+  form = {
+    title: '',
+    date: new Date().toISOString().split('T')[0],
+    time: '18:00',
+    meetingPoint: '',
+    description: '',
+    minParticipants: 1,
+    maxParticipants: 4
+  };
+
+  createAppointment(): void {
+    this.errorMessage = '';
+
+    if (!this.areaId) {
+      this.errorMessage = 'Ungültige Gebiets-ID.';
+      return;
+    }
+
+    if (!this.form.title.trim()) {
+      this.errorMessage = 'Bitte gib einen Titel ein.';
+      return;
+    }
+
+    if (!this.form.date || !this.form.time) {
+      this.errorMessage = 'Bitte gib Datum und Uhrzeit ein.';
+      return;
+    }
+
+    if (this.form.minParticipants && this.form.maxParticipants) {
+      if (this.form.minParticipants > this.form.maxParticipants) {
+        this.errorMessage = 'Minimale Teilnehmerzahl darf nicht größer als maximale Teilnehmerzahl sein.';
+        return;
+      }
+    }
+
+    const appointment: AppointmentCreateRequest = {
+      title: this.form.title.trim(),
+      date: `${this.form.date}T${this.form.time}:00`,
+      meetingPoint: this.form.meetingPoint.trim() || null,
+      description: this.form.description.trim() || null,
+      minParticipants: this.form.minParticipants || null,
+      maxParticipants: this.form.maxParticipants || null
+    };
+
+    this.submitting = true;
+
+    this.areasService.createAppointment(this.areaId, appointment).subscribe({
+      next: () => {
+        this.submitting = false;
+        this.router.navigate(['/areas', this.areaId]);
+      },
+      error: (error) => {
+        console.error('Appointment create error:', error);
+        this.submitting = false;
+
+        if (error.status === 401 || error.status === 403) {
+          this.errorMessage = 'Du musst eingeloggt sein, um eine Klettersession zu erstellen.';
+        } else {
+          this.errorMessage = 'Klettersession konnte nicht erstellt werden.';
+        }
+      }
+    });
+  }
+}

--- a/frontend/src/app/features/areas/area-detail.component.css
+++ b/frontend/src/app/features/areas/area-detail.component.css
@@ -247,3 +247,31 @@
     align-items: flex-start;
   }
 }
+
+.appointments-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.appointments-header h2 {
+  margin: 0;
+}
+
+.create-appointment-button {
+  display: inline-block;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: #f97316;
+  color: white;
+  text-decoration: none;
+  font-weight: 800;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.create-appointment-button:hover {
+  background: #ea580c;
+}

--- a/frontend/src/app/features/areas/area-detail.component.html
+++ b/frontend/src/app/features/areas/area-detail.component.html
@@ -132,8 +132,18 @@
 
       <aside class="side-column">
 
-        <section class="detail-section">
-          <h2>Kommende Termine</h2>
+<section class="detail-section">
+  <div class="appointments-header">
+    <h2>Kommende Termine</h2>
+
+    @if (isLoggedIn()) {
+      <a
+        class="create-appointment-button"
+        [routerLink]="['/areas', area.id, 'appointments', 'new']">
+        Klettersession erstellen
+      </a>
+    }
+  </div>
 
           @if (appointments.length === 0) {
 

--- a/frontend/src/services/areas.service.ts
+++ b/frontend/src/services/areas.service.ts
@@ -41,6 +41,15 @@ export interface AreaComment {
   createdAt?: string | null;
 }
 
+export interface AppointmentCreateRequest {
+  title: string;
+  date: string;
+  meetingPoint?: string | null;
+  description?: string | null;
+  minParticipants?: number | null;
+  maxParticipants?: number | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -73,4 +82,12 @@ export class AreasService {
   getCommentsByArea(areaId: number): Observable<AreaComment[]> {
     return this.http.get<AreaComment[]>(`${this.apiUrl}/areas/${areaId}/comments`);
   }
+
+  createAppointment(areaId: number, appointment: AppointmentCreateRequest): Observable<Appointment> {
+  return this.http.post<Appointment>(
+    `${this.apiUrl}/areas/${areaId}/appointments`,
+    appointment
+  );
+}
+
 }


### PR DESCRIPTION
## Changes

- Added appointment creation form
- Added route /areas/{id}/appointments/new
- Added API call for POST /api/areas/{id}/appointments
- Form includes title, date, time, meeting point, description and min/max participants
- Route is protected by auth guard
- Added create button on area detail page for logged-in users
- Redirects back to area detail page after creating appointment
- Created appointment appears in the area appointment list

## Testing

- Backend started on http://localhost:5004
- Frontend started on http://localhost:4200
- Logged in user can open appointment form
- Appointment can be created successfully
- User is redirected back to area detail page
- Created appointment appears in the area appointment list
- npm run build succeeds

Closes #90
