### PR TITLE
feat: Admin-Interface für Gebiete, Sektoren und Routen (Meilenstein 3)

### DIFF
--- a/frontend/src/app/admin/admin.component.css
+++ b/frontend/src/app/admin/admin.component.css
@@ -1,0 +1,288 @@
+.admin-page {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.admin-header {
+  margin-bottom: 1.5rem;
+}
+
+.admin-header h1 { margin-bottom: 0.25rem; }
+.admin-header p  { color: #6b7280; }
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid #e5e7eb;
+  margin-bottom: 1.5rem;
+}
+
+.tabs button {
+  padding: 0.6rem 1.4rem;
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: #6b7280;
+  font-weight: 500;
+  transition: color 0.15s;
+}
+
+.tabs button.active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+  font-weight: 700;
+}
+
+.tabs button:hover:not(.active) { color: #374151; }
+
+/* Tab-Content */
+.tab-content { }
+
+.section-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.section-toolbar h2 { margin: 0; font-size: 1.1rem; }
+
+.sub-toolbar {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+  font-weight: 600;
+  color: #374151;
+}
+
+/* Picker */
+.picker-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.picker-row label { font-size: 0.9rem; font-weight: 600; color: #374151; }
+
+.picker-row select {
+  padding: 0.45rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  min-width: 200px;
+}
+
+/* Inline Form */
+.inline-form {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.inline-form h3 {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  color: #1e3a5f;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.form-row label { font-size: 0.85rem; font-weight: 600; color: #374151; }
+
+.form-row input,
+.form-row select,
+.form-row textarea {
+  padding: 0.5rem 0.7rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+.form-row textarea { min-height: 70px; resize: vertical; }
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 1rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.6rem;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+/* Table */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.admin-table th {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  background: #f3f4f6;
+  color: #374151;
+  font-weight: 700;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.admin-table td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #f3f4f6;
+  vertical-align: top;
+}
+
+.admin-table tr:hover td { background: #fafafa; }
+
+.desc-cell {
+  max-width: 300px;
+  color: #6b7280;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.actions-cell {
+  white-space: nowrap;
+  text-align: right;
+}
+
+.empty-row {
+  text-align: center;
+  color: #9ca3af;
+  font-style: italic;
+  padding: 1.5rem;
+}
+
+.grade-chip {
+  background: #2563eb;
+  color: #fff;
+  padding: 0.15rem 0.55rem;
+  border-radius: 1rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+/* Buttons */
+.btn-add {
+  padding: 0.45rem 1rem;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.btn-save {
+  padding: 0.45rem 1rem;
+  background: #16a34a;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.btn-cancel {
+  padding: 0.45rem 1rem;
+  background: #f3f4f6;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.btn-edit {
+  padding: 0.3rem 0.7rem;
+  background: #f3f4f6;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+  margin-right: 0.35rem;
+}
+
+.btn-delete {
+  padding: 0.3rem 0.7rem;
+  background: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+}
+
+.btn-danger {
+  padding: 0.5rem 1.1rem;
+  background: #dc2626;
+  color: #fff;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+/* Feedback */
+.msg-success {
+  background: #f0fdf4;
+  color: #15803d;
+  border: 1px solid #bbf7d0;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.msg-error {
+  background: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  padding: 0.6rem 1rem;
+  margin-bottom: 1rem;
+}
+
+/* Gefahrenzone */
+.danger-zone {
+  margin-top: 3rem;
+  border: 1px solid #fecaca;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: #fef2f2;
+}
+
+.danger-zone summary {
+  cursor: pointer;
+  font-weight: 700;
+  color: #dc2626;
+  font-size: 0.95rem;
+}
+
+.danger-zone p {
+  margin: 0.75rem 0 0.5rem;
+  font-size: 0.9rem;
+  color: #374151;
+}

--- a/frontend/src/app/admin/admin.component.html
+++ b/frontend/src/app/admin/admin.component.html
@@ -1,8 +1,283 @@
-<h1>Welcome (Admin)</h1>
+<div class="admin-page">
 
-<div>
-  TODO ... Create admin page.
+  <div class="admin-header">
+    <h1>Admin-Bereich</h1>
+    <p>Gebiete, Sektoren und Routen verwalten</p>
+  </div>
+
+  @if (successMsg) { <p class="msg-success">{{ successMsg }}</p> }
+  @if (errorMsg)   { <p class="msg-error">{{ errorMsg }}</p> }
+
+  <!-- Tabs -->
+  <div class="tabs">
+    <button [class.active]="activeTab === 'areas'"   (click)="setTab('areas')">Gebiete</button>
+    <button [class.active]="activeTab === 'sectors'" (click)="setTab('sectors')">Sektoren</button>
+    <button [class.active]="activeTab === 'routes'"  (click)="setTab('routes')">Routen</button>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: GEBIETE                                                          -->
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  @if (activeTab === 'areas') {
+    <section class="tab-content">
+
+      <div class="section-toolbar">
+        <h2>Klettergebiete</h2>
+        <button class="btn-add" (click)="startCreateArea()">+ Neues Gebiet</button>
+      </div>
+
+      @if (showAreaForm) {
+        <div class="inline-form">
+          <h3>{{ editingArea ? 'Gebiet bearbeiten' : 'Neues Gebiet' }}</h3>
+
+          <div class="form-row">
+            <label>Name *</label>
+            <input type="text" [(ngModel)]="areaForm.name" placeholder="z. B. Traunstein">
+          </div>
+          <div class="form-row">
+            <label>Ort</label>
+            <input type="text" [(ngModel)]="areaForm.location" placeholder="z. B. Gmunden">
+          </div>
+          <div class="form-row">
+            <label>Beschreibung</label>
+            <textarea [(ngModel)]="areaForm.description" placeholder="Kurze Beschreibung des Gebiets..."></textarea>
+          </div>
+          <div class="form-row">
+            <label>Bild-URL</label>
+            <input type="text" [(ngModel)]="areaForm.imageUrl" placeholder="https://...">
+          </div>
+
+          <div class="form-actions">
+            <button class="btn-cancel" (click)="showAreaForm = false">Abbrechen</button>
+            <button class="btn-save" (click)="saveArea()">Speichern</button>
+          </div>
+        </div>
+      }
+
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Ort</th>
+            <th>Beschreibung</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (area of areas; track area.id) {
+            <tr>
+              <td><strong>{{ area.name }}</strong></td>
+              <td>{{ area.location ?? '-' }}</td>
+              <td class="desc-cell">{{ area.description ?? '-' }}</td>
+              <td class="actions-cell">
+                <button class="btn-edit"   (click)="startEditArea(area)">Bearbeiten</button>
+                <button class="btn-delete" (click)="deleteArea(area)">Löschen</button>
+              </td>
+            </tr>
+          }
+          @if (areas.length === 0) {
+            <tr><td colspan="4" class="empty-row">Noch keine Gebiete vorhanden.</td></tr>
+          }
+        </tbody>
+      </table>
+
+    </section>
+  }
+
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: SEKTOREN                                                         -->
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  @if (activeTab === 'sectors') {
+    <section class="tab-content">
+
+      <div class="section-toolbar">
+        <h2>Sektoren</h2>
+      </div>
+
+      <div class="picker-row">
+        <label>Gebiet auswählen:</label>
+        <select (change)="selectAreaForSectors(areas[$any($event.target).selectedIndex - 1])"
+                [disabled]="areas.length === 0">
+          <option value="">— Gebiet wählen —</option>
+          @for (area of areas; track area.id) {
+            <option [value]="area.id">{{ area.name }}</option>
+          }
+        </select>
+      </div>
+
+      @if (selectedAreaForSectors) {
+
+        <div class="section-toolbar sub-toolbar">
+          <span>{{ selectedAreaForSectors.name }}</span>
+          <button class="btn-add" (click)="startCreateSector()">+ Neuer Sektor</button>
+        </div>
+
+        @if (showSectorForm) {
+          <div class="inline-form">
+            <h3>{{ editingSector ? 'Sektor bearbeiten' : 'Neuer Sektor' }}</h3>
+
+            <div class="form-row">
+              <label>Name *</label>
+              <input type="text" [(ngModel)]="sectorForm.name" placeholder="z. B. Nordwand">
+            </div>
+            <div class="form-row">
+              <label>Beschreibung</label>
+              <textarea [(ngModel)]="sectorForm.description" placeholder="Kurze Beschreibung..."></textarea>
+            </div>
+
+            <div class="form-actions">
+              <button class="btn-cancel" (click)="showSectorForm = false">Abbrechen</button>
+              <button class="btn-save"   (click)="saveSector()">Speichern</button>
+            </div>
+          </div>
+        }
+
+        <table class="admin-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Beschreibung</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (sector of sectors; track sector.id) {
+              <tr>
+                <td><strong>{{ sector.name }}</strong></td>
+                <td class="desc-cell">{{ sector.description ?? '-' }}</td>
+                <td class="actions-cell">
+                  <button class="btn-edit"   (click)="startEditSector(sector)">Bearbeiten</button>
+                  <button class="btn-delete" (click)="deleteSector(sector)">Löschen</button>
+                </td>
+              </tr>
+            }
+            @if (sectors.length === 0) {
+              <tr><td colspan="3" class="empty-row">Keine Sektoren für dieses Gebiet.</td></tr>
+            }
+          </tbody>
+        </table>
+
+      }
+
+    </section>
+  }
+
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: ROUTEN                                                           -->
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  @if (activeTab === 'routes') {
+    <section class="tab-content">
+
+      <div class="section-toolbar">
+        <h2>Routen</h2>
+      </div>
+
+      <div class="picker-row">
+        <label>Gebiet:</label>
+        <select (change)="selectAreaForRoutes(areas[$any($event.target).selectedIndex - 1])"
+                [disabled]="areas.length === 0">
+          <option value="">— Gebiet wählen —</option>
+          @for (area of areas; track area.id) {
+            <option [value]="area.id">{{ area.name }}</option>
+          }
+        </select>
+
+        @if (selectedAreaForRoutes && sectorsForRoutes.length > 0) {
+          <label>Sektor:</label>
+          <select (change)="selectSectorForRoutes(sectorsForRoutes[$any($event.target).selectedIndex - 1])">
+            <option value="">— Sektor wählen —</option>
+            @for (sector of sectorsForRoutes; track sector.id) {
+              <option [value]="sector.id">{{ sector.name }}</option>
+            }
+          </select>
+        }
+      </div>
+
+      @if (selectedSectorForRoutes) {
+
+        <div class="section-toolbar sub-toolbar">
+          <span>{{ selectedAreaForRoutes.name }} › {{ selectedSectorForRoutes.name }}</span>
+          <button class="btn-add" (click)="startCreateRoute()">+ Neue Route</button>
+        </div>
+
+        @if (showRouteForm) {
+          <div class="inline-form">
+            <h3>{{ editingRoute ? 'Route bearbeiten' : 'Neue Route' }}</h3>
+
+            <div class="form-grid">
+              <div class="form-row">
+                <label>Name *</label>
+                <input type="text" [(ngModel)]="routeForm.name" placeholder="z. B. Klassischer Riss">
+              </div>
+              <div class="form-row">
+                <label>Grad * (franz. Skala)</label>
+                <input type="text" [(ngModel)]="routeForm.grade" placeholder="z. B. 6a">
+              </div>
+              <div class="form-row">
+                <label>Stil</label>
+                <select [(ngModel)]="routeForm.style">
+                  @for (s of styles; track s) {
+                    <option [value]="s">{{ s }}</option>
+                  }
+                </select>
+              </div>
+              <div class="form-row">
+                <label>Länge (m)</label>
+                <input type="number" [(ngModel)]="routeForm.lengthMeters" placeholder="z. B. 25" min="1">
+              </div>
+            </div>
+
+            <div class="form-row">
+              <label>Beschreibung</label>
+              <textarea [(ngModel)]="routeForm.description" placeholder="Routenbeschreibung, Charakter..."></textarea>
+            </div>
+
+            <div class="form-actions">
+              <button class="btn-cancel" (click)="showRouteForm = false">Abbrechen</button>
+              <button class="btn-save"   (click)="saveRoute()">Speichern</button>
+            </div>
+          </div>
+        }
+
+        <table class="admin-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Grad</th>
+              <th>Stil</th>
+              <th>Länge</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (route of routes; track route.id) {
+              <tr>
+                <td><strong>{{ route.name }}</strong></td>
+                <td><span class="grade-chip">{{ route.grade }}</span></td>
+                <td>{{ route.style ?? '-' }}</td>
+                <td>{{ route.lengthMeters ? route.lengthMeters + ' m' : '-' }}</td>
+                <td class="actions-cell">
+                  <button class="btn-edit"   (click)="startEditRoute(route)">Bearbeiten</button>
+                  <button class="btn-delete" (click)="deleteRoute(route)">Löschen</button>
+                </td>
+              </tr>
+            }
+            @if (routes.length === 0) {
+              <tr><td colspan="5" class="empty-row">Keine Routen in diesem Sektor.</td></tr>
+            }
+          </tbody>
+        </table>
+
+      }
+
+    </section>
+  }
+
+  <!-- Gefahrenzone -->
+  <details class="danger-zone">
+    <summary>⚠ Gefahrenzone</summary>
+    <p>Setzt die gesamte Datenbank zurück und lädt Seed-Daten neu. <strong>Alle Einträge werden gelöscht.</strong></p>
+    <button class="btn-danger" (click)="initDatabase()">Datenbank zurücksetzen</button>
+  </details>
+
 </div>
-<br/>
-<h1>Admin DANGER ZONE</h1>
-<button class="btn btn-danger btn-sm" (click)="initDatabase()">Init Database</button>

--- a/frontend/src/app/admin/admin.component.ts
+++ b/frontend/src/app/admin/admin.component.ts
@@ -1,22 +1,275 @@
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { AdminService } from '../../services/admin.service';
+
 @Component({
   selector: 'app-admin',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.css']
 })
-export class AdminComponent {
+export class AdminComponent implements OnInit {
 
   private adminService = inject(AdminService);
 
+  activeTab: 'areas' | 'sectors' | 'routes' = 'areas';
+
+  // ── Gebiete ────────────────────────────────────────────────────────────────
+  areas: any[] = [];
+  showAreaForm = false;
+  editingArea: any = null;
+  areaForm = { name: '', location: '', description: '', imageUrl: '' };
+
+  // ── Sektoren ───────────────────────────────────────────────────────────────
+  selectedAreaForSectors: any = null;
+  sectors: any[] = [];
+  showSectorForm = false;
+  editingSector: any = null;
+  sectorForm = { name: '', description: '' };
+
+  // ── Routen ─────────────────────────────────────────────────────────────────
+  selectedAreaForRoutes: any = null;
+  sectorsForRoutes: any[] = [];
+  selectedSectorForRoutes: any = null;
+  routes: any[] = [];
+  showRouteForm = false;
+  editingRoute: any = null;
+  routeForm = { name: '', grade: '', style: '', lengthMeters: null as number | null, description: '' };
+
+  errorMsg = '';
+  successMsg = '';
+
+  readonly styles = ['Sport', 'Trad', 'Boulder', 'Multi-Pitch', 'Klettersteig'];
+
+  ngOnInit(): void {
+    this.loadAreas();
+  }
+
+  setTab(tab: 'areas' | 'sectors' | 'routes'): void {
+    this.activeTab = tab;
+    this.clearMessages();
+    this.resetForms();
+  }
+
+  // ── Gebiete ────────────────────────────────────────────────────────────────
+
+  loadAreas(): void {
+    this.adminService.getAreas().subscribe({
+      next: (data) => { this.areas = data; },
+      error: () => { this.errorMsg = 'Gebiete konnten nicht geladen werden.'; }
+    });
+  }
+
+  startCreateArea(): void {
+    this.editingArea = null;
+    this.areaForm = { name: '', location: '', description: '', imageUrl: '' };
+    this.showAreaForm = true;
+  }
+
+  startEditArea(area: any): void {
+    this.editingArea = area;
+    this.areaForm = {
+      name: area.name ?? '',
+      location: area.location ?? '',
+      description: area.description ?? '',
+      imageUrl: area.imageUrl ?? ''
+    };
+    this.showAreaForm = true;
+  }
+
+  saveArea(): void {
+    if (!this.areaForm.name.trim()) { this.errorMsg = 'Name ist erforderlich.'; return; }
+    this.clearMessages();
+
+    const payload = {
+      name:        this.areaForm.name.trim(),
+      location:    this.areaForm.location.trim() || null,
+      description: this.areaForm.description.trim() || null,
+      imageUrl:    this.areaForm.imageUrl.trim() || null
+    };
+
+    const req = this.editingArea
+      ? this.adminService.updateArea(this.editingArea.id, payload)
+      : this.adminService.createArea(payload);
+
+    req.subscribe({
+      next: () => {
+        this.successMsg = this.editingArea ? 'Gebiet aktualisiert.' : 'Gebiet erstellt.';
+        this.showAreaForm = false;
+        this.loadAreas();
+      },
+      error: (err) => { this.errorMsg = err?.error?.error ?? 'Fehler beim Speichern.'; }
+    });
+  }
+
+  deleteArea(area: any): void {
+    if (!confirm(`Gebiet "${area.name}" wirklich löschen? Alle zugehörigen Sektoren und Routen werden ebenfalls gelöscht.`)) return;
+    this.adminService.deleteArea(area.id).subscribe({
+      next: () => { this.successMsg = 'Gebiet gelöscht.'; this.loadAreas(); },
+      error: (err) => { this.errorMsg = err?.error?.error ?? 'Fehler beim Löschen.'; }
+    });
+  }
+
+  // ── Sektoren ───────────────────────────────────────────────────────────────
+
+  selectAreaForSectors(area: any): void {
+    this.selectedAreaForSectors = area;
+    this.showSectorForm = false;
+    this.editingSector = null;
+    this.clearMessages();
+    this.adminService.getSectorsByArea(area.id).subscribe({
+      next: (data) => { this.sectors = data; },
+      error: () => { this.errorMsg = 'Sektoren konnten nicht geladen werden.'; }
+    });
+  }
+
+  startCreateSector(): void {
+    this.editingSector = null;
+    this.sectorForm = { name: '', description: '' };
+    this.showSectorForm = true;
+  }
+
+  startEditSector(sector: any): void {
+    this.editingSector = sector;
+    this.sectorForm = { name: sector.name ?? '', description: sector.description ?? '' };
+    this.showSectorForm = true;
+  }
+
+  saveSector(): void {
+    if (!this.sectorForm.name.trim()) { this.errorMsg = 'Name ist erforderlich.'; return; }
+    this.clearMessages();
+
+    const payload = {
+      name:        this.sectorForm.name.trim(),
+      description: this.sectorForm.description.trim() || null
+    };
+
+    const req = this.editingSector
+      ? this.adminService.updateSector(this.editingSector.id, payload)
+      : this.adminService.createSector(this.selectedAreaForSectors.id, payload);
+
+    req.subscribe({
+      next: () => {
+        this.successMsg = this.editingSector ? 'Sektor aktualisiert.' : 'Sektor erstellt.';
+        this.showSectorForm = false;
+        this.selectAreaForSectors(this.selectedAreaForSectors);
+      },
+      error: (err) => { this.errorMsg = err?.error?.error ?? 'Fehler beim Speichern.'; }
+    });
+  }
+
+  deleteSector(sector: any): void {
+    if (!confirm(`Sektor "${sector.name}" wirklich löschen? Alle zugehörigen Routen werden ebenfalls gelöscht.`)) return;
+    this.adminService.deleteSector(sector.id).subscribe({
+      next: () => {
+        this.successMsg = 'Sektor gelöscht.';
+        this.selectAreaForSectors(this.selectedAreaForSectors);
+      },
+      error: (err) => { this.errorMsg = err?.error?.error ?? 'Fehler beim Löschen.'; }
+    });
+  }
+
+  // ── Routen ─────────────────────────────────────────────────────────────────
+
+  selectAreaForRoutes(area: any): void {
+    this.selectedAreaForRoutes = area;
+    this.selectedSectorForRoutes = null;
+    this.routes = [];
+    this.showRouteForm = false;
+    this.clearMessages();
+    this.adminService.getSectorsByArea(area.id).subscribe({
+      next: (data) => { this.sectorsForRoutes = data; },
+      error: () => { this.errorMsg = 'Sektoren konnten nicht geladen werden.'; }
+    });
+  }
+
+  selectSectorForRoutes(sector: any): void {
+    this.selectedSectorForRoutes = sector;
+    this.showRouteForm = false;
+    this.editingRoute = null;
+    this.clearMessages();
+    this.adminService.getRoutesBySector(sector.id).subscribe({
+      next: (data) => { this.routes = data; },
+      error: () => { this.errorMsg = 'Routen konnten nicht geladen werden.'; }
+    });
+  }
+
+  startCreateRoute(): void {
+    this.editingRoute = null;
+    this.routeForm = { name: '', grade: '', style: 'Sport', lengthMeters: null, description: '' };
+    this.showRouteForm = true;
+  }
+
+  startEditRoute(route: any): void {
+    this.editingRoute = route;
+    this.routeForm = {
+      name:         route.name ?? '',
+      grade:        route.grade ?? '',
+      style:        route.style ?? 'Sport',
+      lengthMeters: route.lengthMeters ?? null,
+      description:  route.description ?? ''
+    };
+    this.showRouteForm = true;
+  }
+
+  saveRoute(): void {
+    if (!this.routeForm.name.trim()) { this.errorMsg = 'Name ist erforderlich.'; return; }
+    if (!this.routeForm.grade.trim()) { this.errorMsg = 'Grad ist erforderlich (franz. Skala, z. B. 6a).'; return; }
+    this.clearMessages();
+
+    const payload = {
+      name:         this.routeForm.name.trim(),
+      grade:        this.routeForm.grade.trim().toLowerCase(),
+      style:        this.routeForm.style.trim() || null,
+      lengthMeters: this.routeForm.lengthMeters ?? null,
+      description:  this.routeForm.description.trim() || null
+    };
+
+    const req = this.editingRoute
+      ? this.adminService.updateRoute(this.editingRoute.id, payload)
+      : this.adminService.createRoute(this.selectedSectorForRoutes.id, payload);
+
+    req.subscribe({
+      next: () => {
+        this.successMsg = this.editingRoute ? 'Route aktualisiert.' : 'Route erstellt.';
+        this.showRouteForm = false;
+        this.selectSectorForRoutes(this.selectedSectorForRoutes);
+      },
+      error: (err) => { this.errorMsg = err?.error?.error ?? 'Fehler beim Speichern.'; }
+    });
+  }
+
+  deleteRoute(route: any): void {
+    if (!confirm(`Route "${route.name}" wirklich löschen?`)) return;
+    this.adminService.deleteRoute(route.id).subscribe({
+      next: () => {
+        this.successMsg = 'Route gelöscht.';
+        this.selectSectorForRoutes(this.selectedSectorForRoutes);
+      },
+      error: (err) => { this.errorMsg = err?.error?.error ?? 'Fehler beim Löschen.'; }
+    });
+  }
+
+  // ── Datenbank zurücksetzen ─────────────────────────────────────────────────
+
   initDatabase(): void {
-    if (confirm(`Do you really want to delete everything and re-initialize the database?`)) {
-      this.adminService.initDatabase().subscribe({
-        next: () => { },
-        error: error => {
-          console.error('Error deleting:');
-        }
-      });
-    }
+    if (!confirm('Wirklich alles löschen und Datenbank neu initialisieren?')) return;
+    this.adminService.initDatabase().subscribe({
+      next: () => { this.successMsg = 'Datenbank zurückgesetzt.'; this.loadAreas(); },
+      error: () => { this.errorMsg = 'Fehler beim Zurücksetzen.'; }
+    });
+  }
+
+  private clearMessages(): void { this.errorMsg = ''; this.successMsg = ''; }
+
+  private resetForms(): void {
+    this.showAreaForm = false;
+    this.showSectorForm = false;
+    this.showRouteForm = false;
+    this.editingArea = null;
+    this.editingSector = null;
+    this.editingRoute = null;
   }
 }

--- a/frontend/src/services/admin.service.ts
+++ b/frontend/src/services/admin.service.ts
@@ -1,28 +1,74 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../environments/environment';
 
-const httpOptions = {
-  headers: new HttpHeaders({
-    'Content-Type': 'application/json'
-  })
-}
 @Injectable({
   providedIn: 'root'
 })
 export class AdminService {
 
-  private apiUrl = "/api";  // will be replaced by environment variable
+  private api = environment.apiUrl + '/api';
 
-  constructor(private http: HttpClient) { 
-    this.apiUrl = environment.apiUrl;
-    console.log("API URL: " + this.apiUrl);
+  constructor(private http: HttpClient) {}
+
+  // ── Gebiete ────────────────────────────────────────────────────────────────
+
+  getAreas(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.api}/areas`);
   }
 
-  initDatabase() {
-    const url = `${this.apiUrl}/Admin`;
-    return this.http.put(url, null);
+  createArea(data: { name: string; location?: string | null; description?: string | null; imageUrl?: string | null }): Observable<any> {
+    return this.http.post(`${this.api}/areas`, data);
   }
 
+  updateArea(id: number, data: { name: string; location?: string | null; description?: string | null; imageUrl?: string | null }): Observable<any> {
+    return this.http.put(`${this.api}/areas/${id}`, data);
+  }
+
+  deleteArea(id: number): Observable<any> {
+    return this.http.delete(`${this.api}/areas/${id}`);
+  }
+
+  // ── Sektoren ───────────────────────────────────────────────────────────────
+
+  getSectorsByArea(areaId: number): Observable<any[]> {
+    return this.http.get<any[]>(`${this.api}/areas/${areaId}/sectors`);
+  }
+
+  createSector(areaId: number, data: { name: string; description?: string | null }): Observable<any> {
+    return this.http.post(`${this.api}/areas/${areaId}/sectors`, data);
+  }
+
+  updateSector(id: number, data: { name: string; description?: string | null }): Observable<any> {
+    return this.http.put(`${this.api}/sectors/${id}`, data);
+  }
+
+  deleteSector(id: number): Observable<any> {
+    return this.http.delete(`${this.api}/sectors/${id}`);
+  }
+
+  // ── Routen ─────────────────────────────────────────────────────────────────
+
+  getRoutesBySector(sectorId: number): Observable<any[]> {
+    return this.http.get<any[]>(`${this.api}/sectors/${sectorId}/routes`);
+  }
+
+  createRoute(sectorId: number, data: { name: string; grade: string; style?: string | null; lengthMeters?: number | null; description?: string | null }): Observable<any> {
+    return this.http.post(`${this.api}/sectors/${sectorId}/routes`, data);
+  }
+
+  updateRoute(id: number, data: { name: string; grade: string; style?: string | null; lengthMeters?: number | null; description?: string | null }): Observable<any> {
+    return this.http.put(`${this.api}/routes/${id}`, data);
+  }
+
+  deleteRoute(id: number): Observable<any> {
+    return this.http.delete(`${this.api}/routes/${id}`);
+  }
+
+  // ── Datenbank zurücksetzen (Gefahrenzone) ──────────────────────────────────
+
+  initDatabase(): Observable<any> {
+    return this.http.put(`${this.api}/Admin`, null);
+  }
 }


### PR DESCRIPTION
## Summary

Meilenstein 3 ist damit frontend-seitig vollständig abgedeckt. Admins können jetzt über das Web-Interface alle Inhalte verwalten.

### Was gebaut wurde

**AdminComponent** — 3 Tabs:

| Tab | Was man kann |
|---|---|
| Gebiete | Alle Gebiete sehen, neues Gebiet anlegen (Name, Ort, Beschreibung, Bild-URL), bearbeiten, löschen |
| Sektoren | Gebiet auswählen → Sektoren dieses Gebiets anzeigen, anlegen, bearbeiten, löschen |
| Routen | Gebiet + Sektor auswählen → Routen mit Grad, Stil, Länge anlegen, bearbeiten, löschen |

**AdminService** — alle CRUD-Methoden: `createArea`, `updateArea`, `deleteArea`, `createSector`, `updateSector`, `deleteSector`, `createRoute`, `updateRoute`, `deleteRoute`

- Löschen nur nach Browser-Bestätigung (kein versehentliches Löschen)
- Datenbank-Reset in zugeklappter "Gefahrenzone" am Seitenende
- Erfolgsmeldungen und Fehlermeldungen werden angezeigt

## Test plan

- [ ] Als Admin einloggen und `/admin` aufrufen
- [ ] Tab "Gebiete" → "Neues Gebiet" anlegen → erscheint in der Liste
- [ ] Gebiet bearbeiten → Änderungen werden gespeichert
- [ ] Tab "Sektoren" → Gebiet auswählen → Sektor anlegen
- [ ] Tab "Routen" → Gebiet + Sektor wählen → Route mit Grad "6a" anlegen
- [ ] Route bearbeiten → Grad ändern → gespeichert
- [ ] Route löschen → Bestätigungsdialog erscheint → nach Bestätigung gelöscht
- [ ] Normaler User sieht `/admin` nicht (Guard leitet weiter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)