### PR TITLE
feat: Subjektiven Grad als Dropdown im Progress-Formular (closes #94)

### DIFF
--- a/frontend/src/app/features/progress/progress-form.component.html
+++ b/frontend/src/app/features/progress/progress-form.component.html
@@ -41,8 +41,13 @@
     </div>
 
     <div class="form-field">
-      <label for="grade">Subjektive Gradeinschätzung (franz., optional)</label>
-      <input id="grade" type="text" [(ngModel)]="form.subjectiveGrade" placeholder="z. B. 6b">
+      <label for="grade">Subjektive Gradeinschätzung (optional)</label>
+      <select id="grade" [(ngModel)]="form.subjectiveGrade">
+        <option value="">— kein Grad —</option>
+        @for (g of frenchGrades; track g) {
+          <option [value]="g">{{ g }}</option>
+        }
+      </select>
     </div>
 
     <div class="form-field">

--- a/frontend/src/app/features/progress/progress-form.component.ts
+++ b/frontend/src/app/features/progress/progress-form.component.ts
@@ -29,6 +29,15 @@ export class ProgressFormComponent implements OnInit {
   statuses        = ['Rotpunkt', 'Flash', 'Onsight', 'Projekt', 'Toprope'];
   climbingStyles  = ['Vorstieg', 'Toprope'];
 
+  frenchGrades = [
+    '3a','3b','3c','4a','4b','4c',
+    '5a','5b','5c',
+    '6a','6a+','6b','6b+','6c','6c+',
+    '7a','7a+','7b','7b+','7c','7c+',
+    '8a','8a+','8b','8b+','8c','8c+',
+    '9a','9a+','9b','9b+','9c'
+  ];
+
   submitting = false;
   errorMessage = '';
 


### PR DESCRIPTION
## Summary

Closes #94 — alle drei Akzeptanzkriterien sind damit erfüllt:

| Kriterium | Status |
|---|---|
| Begehung mit Status und subjektivem Grad eintragbar | ✅ ProgressFormComponent |
| Kommentar mit Foto möglich | ✅ RouteDetailComponent |
| Community-Grad sichtbar | ✅ RouteDetailComponent |

**Diese Änderung:** Das Freitext-Feld für den subjektiven Grad wurde durch ein Dropdown mit allen gültigen französischen Graden ersetzt (3a bis 9c). Das verhindert Tippfehler und ungültige Eingaben.

## Test plan

- [ ] `/routes/1` aufrufen → "Begehung eintragen" klicken
- [ ] Subjektiver Grad → Dropdown zeigt alle Grades von 3a bis 9c
- [ ] Formular speichern → Begehung wird gespeichert
- [ ] Im Profil → Begehung erscheint in der Liste

🤖 Generated with [Claude Code](https://claude.com/claude-code)