### PR TITLE
docs: add manual test cases

### DIFF
--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,55 @@
+# Manuelle Testfälle – ClimbConnect Frontend
+
+Diese Testdokumentation gehört zu **User Story #25 – Manuelle Testfälle definieren**.
+
+Ziel: Die wichtigsten Hauptfunktionen werden manuell getestet, damit sichtbar ist, ob die Anwendung korrekt und stabil funktioniert.
+
+## Voraussetzung
+
+- Backend läuft lokal.
+- Frontend läuft mit `npm start`.
+- Browser öffnet `http://localhost:4200`.
+- Es gibt mindestens einen normalen Testuser.
+- Für Admin-Funktionen ist ein Admin-User optional, aber für diese User Story nicht zwingend notwendig.
+- In der Datenbank gibt es Testdaten für Areas, Sectors, Routes, Appointments und Comments.
+
+## Testdaten
+
+| Wert | Beispiel |
+|---|---|
+| Frontend URL | `http://localhost:4200` |
+| Testuser | normaler eingeloggter User |
+| Area-ID | eine vorhandene Area, z. B. `1` |
+| Route-ID | eine vorhandene Route, z. B. `1` |
+| Bilddatei gültig | `.jpg` oder `.png`, kleiner als 5 MB |
+| Bilddatei ungültig | Bild größer als 5 MB |
+
+## Dateien in diesem Ordner
+
+| Datei | Inhalt |
+|---|---|
+| `areas.md` | Testfälle für Area-Liste, Area-Detail, Sektoren und Routenliste |
+| `routes.md` | Testfälle für Routendetail, Community Grade und Safety Reports |
+| `progress.md` | Testfälle für Begehungen / Progress |
+| `appointments.md` | Testfälle für Klettersessions / Termine |
+| `comments.md` | Testfälle für Kommentare |
+| `test-protocol-template.md` | Vorlage zum Eintragen der Testergebnisse |
+
+## Status-Legende
+
+| Status | Bedeutung |
+|---|---|
+| Offen | Noch nicht getestet |
+| OK | Test erfolgreich |
+| Fehler | Test fehlgeschlagen |
+| Blockiert | Test konnte nicht durchgeführt werden |
+
+## Wichtig
+
+Bei jedem Test soll eingetragen werden:
+
+- Datum
+- Tester
+- Browser
+- Ergebnis
+- kurze Notiz, falls ein Fehler gefunden wurde

--- a/docs/tests/appointments.md
+++ b/docs/tests/appointments.md
@@ -1,0 +1,102 @@
+# Manuelle Testfälle – Appointments
+
+Bereich: **Klettersessions / Termine erstellen, anzeigen, beitreten und austreten**
+
+## AP-001 – Termine auf Area-Detailseite anzeigen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Area existiert. Es gibt mindestens einen Termin oder keine Termine. |
+| Schritte | 1. `/areas/{id}` öffnen. 2. Abschnitt „Kommende Termine“ prüfen. |
+| Erwartetes Ergebnis | Vorhandene Termine werden mit Titel, Datum und Teilnehmeranzahl angezeigt. Wenn keine Termine vorhanden sind, steht „Keine Termine vorhanden.“ |
+| Status | Offen |
+
+## AP-002 – Button „Klettersession erstellen“ nur mit Login
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Area existiert. |
+| Schritte | 1. Ausloggen. 2. `/areas/{id}` öffnen. 3. Einloggen. 4. Seite erneut öffnen. |
+| Erwartetes Ergebnis | Ohne Login ist der Button nicht sichtbar. Mit Login ist „Klettersession erstellen“ sichtbar. |
+| Status | Offen |
+
+## AP-003 – Direkter Zugriff ohne Login blockiert
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist ausgeloggt. |
+| Schritte | 1. URL `/areas/{id}/appointments/new` öffnen. |
+| Erwartetes Ergebnis | User wird zur Login-Seite weitergeleitet. |
+| Status | Offen |
+
+## AP-004 – Formular mit Standardwerten öffnen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Area existiert. |
+| Schritte | 1. Area-Detailseite öffnen. 2. „Klettersession erstellen“ klicken. |
+| Erwartetes Ergebnis | Formular öffnet sich. Datum ist heute, Uhrzeit ist `18:00`, minimale Teilnehmer ist `1`, maximale Teilnehmer ist `4`. |
+| Status | Offen |
+
+## AP-005 – Titel ist Pflichtfeld
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Appointment-Formular ist geöffnet. |
+| Schritte | 1. Titel leer lassen. 2. „Klettersession erstellen“ klicken. |
+| Erwartetes Ergebnis | Es erscheint „Bitte gib einen Titel ein.“ Es wird kein Termin erstellt. |
+| Status | Offen |
+
+## AP-006 – Datum und Uhrzeit sind Pflichtfelder
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Appointment-Formular ist geöffnet. |
+| Schritte | 1. Titel eintragen. 2. Datum oder Uhrzeit löschen. 3. Speichern klicken. |
+| Erwartetes Ergebnis | Es erscheint „Bitte gib Datum und Uhrzeit ein.“ Es wird kein Termin erstellt. |
+| Status | Offen |
+
+## AP-007 – Min. Teilnehmer größer als Max. Teilnehmer
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Appointment-Formular ist geöffnet. |
+| Schritte | 1. Titel eintragen. 2. Min. Teilnehmer auf `5` setzen. 3. Max. Teilnehmer auf `2` setzen. 4. Speichern klicken. |
+| Erwartetes Ergebnis | Es erscheint „Minimale Teilnehmerzahl darf nicht größer als maximale Teilnehmerzahl sein.“ |
+| Status | Offen |
+
+## AP-008 – Termin erfolgreich erstellen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Backend läuft. |
+| Schritte | 1. Appointment-Formular öffnen. 2. Gültigen Titel, Datum, Uhrzeit und optionale Felder ausfüllen. 3. „Klettersession erstellen“ klicken. |
+| Erwartetes Ergebnis | Termin wird gespeichert. User wird zurück zur Area-Detailseite geleitet. Neuer Termin erscheint in „Kommende Termine“. |
+| Status | Offen |
+
+## AP-009 – Termin beitreten
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Es gibt einen Termin. |
+| Schritte | 1. Area-Detailseite öffnen. 2. Bei einem Termin „Beitreten“ klicken. |
+| Erwartetes Ergebnis | Button ändert sich zu „Austreten“. Teilnehmeranzahl erhöht sich um `1`. |
+| Status | Offen |
+
+## AP-010 – Termin austreten
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt und ist einem Termin beigetreten. |
+| Schritte | 1. Bei diesem Termin „Austreten“ klicken. |
+| Erwartetes Ergebnis | Button ändert sich zu „Beitreten“. Teilnehmeranzahl verringert sich um `1`, aber nicht unter `0`. |
+| Status | Offen |
+
+## AP-011 – Backend-Fehler beim Erstellen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Backend liefert Fehler oder ist nicht erreichbar. |
+| Schritte | 1. Appointment-Formular gültig ausfüllen. 2. Backend stoppen oder Fehler provozieren. 3. Speichern klicken. |
+| Erwartetes Ergebnis | Es erscheint „Klettersession konnte nicht erstellt werden.“ oder bei Auth-Problem „Du musst eingeloggt sein, um eine Klettersession zu erstellen.“ |
+| Status | Offen |

--- a/docs/tests/areas.md
+++ b/docs/tests/areas.md
@@ -1,0 +1,93 @@
+# Manuelle Testfälle – Areas
+
+Bereich: **Areas, Area-Detail, Sektoren und Routenliste**
+
+## AR-001 – Area-Liste laden
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Backend und Frontend laufen. Es gibt mindestens eine Area. |
+| Schritte | 1. Browser öffnen. 2. `http://localhost:4200/areas` aufrufen. |
+| Erwartetes Ergebnis | Die Seite „Climbing Areas“ wird angezeigt. Area-Karten werden geladen. Name, Standort, Beschreibung und Besucheranzahl werden angezeigt. |
+| Status | Offen |
+
+## AR-002 – Loading-Anzeige prüfen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Backend reagiert langsam oder Seite wird neu geladen. |
+| Schritte | 1. `/areas` öffnen. 2. Direkt beim Laden auf die Anzeige achten. |
+| Erwartetes Ergebnis | Während des Ladens erscheint „Gebiete werden geladen...“ mit Spinner. |
+| Status | Offen |
+
+## AR-003 – Fehlerfall beim Laden der Areas
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Backend ist gestoppt oder nicht erreichbar. |
+| Schritte | 1. Backend stoppen. 2. `/areas` öffnen. 3. Button „Nochmal versuchen“ klicken. |
+| Erwartetes Ergebnis | Es erscheint „Gebiete konnten nicht geladen werden.“ Der Button versucht die Daten erneut zu laden. |
+| Status | Offen |
+
+## AR-004 – Leere Area-Liste
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Backend liefert keine Areas zurück. |
+| Schritte | 1. `/areas` öffnen. |
+| Erwartetes Ergebnis | Es erscheint „Es wurden keine Gebiete gefunden.“ |
+| Status | Offen |
+
+## AR-005 – Area-Detail öffnen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Es gibt mindestens eine Area in der Liste. |
+| Schritte | 1. `/areas` öffnen. 2. Auf eine Area-Karte klicken. |
+| Erwartetes Ergebnis | Die Detailseite `/areas/{id}` öffnet sich. Name, Standort, Beschreibung und Bild oder Platzhalter werden angezeigt. |
+| Status | Offen |
+
+## AR-006 – Zurück-Link auf Area-Detailseite
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Eine Area-Detailseite ist geöffnet. |
+| Schritte | 1. Auf „← Zurück zu Areas“ klicken. |
+| Erwartetes Ergebnis | Der Benutzer kommt zurück zur Area-Liste. |
+| Status | Offen |
+
+## AR-007 – Sektoren aufklappen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Area hat mindestens einen Sektor. |
+| Schritte | 1. Area-Detailseite öffnen. 2. In „Sektoren & Routen“ auf einen Sektor klicken. |
+| Erwartetes Ergebnis | Der Sektor klappt auf. Während des Ladens erscheint „Routen werden geladen...“. Danach werden die Routen angezeigt oder der Hinweis „Keine Routen vorhanden.“ |
+| Status | Offen |
+
+## AR-008 – Routen in Sektor anzeigen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Ein Sektor hat mindestens eine Route. |
+| Schritte | 1. Area-Detailseite öffnen. 2. Sektor aufklappen. |
+| Erwartetes Ergebnis | Eine Tabelle mit Name, Grad, Länge und Stil wird angezeigt. Fehlende Werte werden mit `-` dargestellt. |
+| Status | Offen |
+
+## AR-009 – Ungültige Area-ID
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Frontend läuft. |
+| Schritte | 1. URL `/areas/abc` aufrufen. |
+| Erwartetes Ergebnis | Es erscheint „Ungültige Area-ID.“ |
+| Status | Offen |
+
+## AR-010 – Nicht vorhandene Area-ID
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Backend läuft. Die Area-ID existiert nicht, z. B. `999999`. |
+| Schritte | 1. URL `/areas/999999` aufrufen. |
+| Erwartetes Ergebnis | Es erscheint „Gebiet konnte nicht geladen werden.“ |
+| Status | Offen |

--- a/docs/tests/comments.md
+++ b/docs/tests/comments.md
@@ -1,0 +1,84 @@
+# Manuelle Testfälle – Comments
+
+Bereich: **Kommentare auf Area- und Routenseiten**
+
+## CM-001 – Area-Kommentare anzeigen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Area existiert. Es gibt Kommentare oder keine Kommentare. |
+| Schritte | 1. `/areas/{id}` öffnen. 2. Abschnitt „Kommentare“ prüfen. |
+| Erwartetes Ergebnis | Vorhandene Kommentare werden mit Autor, Text und Datum angezeigt. Wenn keine Kommentare vorhanden sind, steht „Keine Kommentare vorhanden.“ |
+| Status | Offen |
+
+## CM-002 – Area-Kommentar Button nur mit Login
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Area existiert. |
+| Schritte | 1. Ausloggen. 2. `/areas/{id}` öffnen. 3. Einloggen und Seite erneut öffnen. |
+| Erwartetes Ergebnis | Ohne Login ist der Button „Kommentar schreiben“ nicht sichtbar. Mit Login ist der Button sichtbar. |
+| Status | Offen |
+
+## CM-003 – Route-Kommentare anzeigen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Route existiert. |
+| Schritte | 1. `/routes/{id}` öffnen. 2. Abschnitt „Kommentare“ prüfen. |
+| Erwartetes Ergebnis | Kommentare werden angezeigt oder es erscheint „Noch keine Kommentare.“ |
+| Status | Offen |
+
+## CM-004 – Route-Kommentar Formular nur mit Login
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Route existiert. |
+| Schritte | 1. Ausloggen. 2. `/routes/{id}` öffnen. 3. Einloggen und Seite erneut öffnen. |
+| Erwartetes Ergebnis | Ohne Login ist kein Kommentarformular sichtbar. Mit Login sind Textfeld, Datei-Upload und Button „Kommentar abschicken“ sichtbar. |
+| Status | Offen |
+
+## CM-005 – Route-Kommentar Text ist Pflicht
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Routendetailseite ist geöffnet. |
+| Schritte | 1. Kommentartext leer lassen. 2. Button prüfen. |
+| Erwartetes Ergebnis | Button „Kommentar abschicken“ ist deaktiviert, solange kein Text eingegeben wurde. |
+| Status | Offen |
+
+## CM-006 – Route-Kommentar ohne Bild speichern
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Route existiert. |
+| Schritte | 1. Kommentartext eingeben. 2. Kein Bild auswählen. 3. „Kommentar abschicken“ klicken. |
+| Erwartetes Ergebnis | Kommentar wird gespeichert. Erfolgsmeldung „Kommentar gespeichert!“ erscheint. Kommentar steht oben in der Liste. |
+| Status | Offen |
+
+## CM-007 – Route-Kommentar mit Bild kleiner als 5 MB speichern
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Es gibt ein gültiges Bild kleiner als 5 MB. |
+| Schritte | 1. Kommentartext eingeben. 2. Bild auswählen. 3. Vorschau prüfen. 4. Kommentar abschicken. |
+| Erwartetes Ergebnis | Bildvorschau wird angezeigt. Kommentar wird mit Bild gespeichert. |
+| Status | Offen |
+
+## CM-008 – Route-Kommentar Bild größer als 5 MB
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Es gibt ein Bild größer als 5 MB. |
+| Schritte | 1. Bild größer als 5 MB im Kommentarformular auswählen. |
+| Erwartetes Ergebnis | Es erscheint „Bild darf maximal 5 MB groß sein.“ Kommentar wird nicht mit diesem Bild abgeschickt. |
+| Status | Offen |
+
+## CM-009 – Backend-Fehler beim Kommentar speichern
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Backend liefert Fehler oder ist nicht erreichbar. |
+| Schritte | 1. Kommentartext eingeben. 2. Backend stoppen oder Fehler provozieren. 3. Kommentar abschicken. |
+| Erwartetes Ergebnis | Es erscheint „Kommentar konnte nicht gespeichert werden.“ Button wird wieder benutzbar. |
+| Status | Offen |

--- a/docs/tests/progress.md
+++ b/docs/tests/progress.md
@@ -1,0 +1,75 @@
+# Manuelle Testfälle – Progress
+
+Bereich: **Begehung eintragen und Profil-Fortschritt**
+
+## PR-001 – Progress-Seite ohne Login schützen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist ausgeloggt. |
+| Schritte | 1. URL `/progress/new?routeId=1&routeName=Test` öffnen. |
+| Erwartetes Ergebnis | User wird zur Login-Seite weitergeleitet. |
+| Status | Offen |
+
+## PR-002 – Progress-Formular öffnen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Gültige Route-ID ist vorhanden. |
+| Schritte | 1. Routendetail öffnen. 2. „+ Begehung eintragen“ klicken. |
+| Erwartetes Ergebnis | Formular zeigt RouteName an. Felder Status, Begehungsart, Anzahl Versuche, Datum, Notizen und subjektive Gradeinschätzung sind sichtbar. |
+| Status | Offen |
+
+## PR-003 – Standardwerte prüfen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Progress-Formular ist geöffnet. |
+| Schritte | 1. Felder im Formular ansehen. |
+| Erwartetes Ergebnis | Status ist „Rotpunkt“, Begehungsart ist „Vorstieg“, Versuche ist `1`, Datum ist heutiges Datum. |
+| Status | Offen |
+
+## PR-004 – Ungültige Route-ID
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. |
+| Schritte | 1. URL `/progress/new` ohne `routeId` öffnen. 2. „Begehung speichern“ klicken. |
+| Erwartetes Ergebnis | Es erscheint „Ungültige Routen-ID.“ |
+| Status | Offen |
+
+## PR-005 – Begehung speichern
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Gültige Route-ID ist vorhanden. |
+| Schritte | 1. Progress-Formular öffnen. 2. Status auswählen. 3. Begehungsart auswählen. 4. Anzahl Versuche eintragen. 5. Optional Notiz und subjektiven Grad eintragen. 6. „Begehung speichern“ klicken. |
+| Erwartetes Ergebnis | Begehung wird gespeichert. User wird zurück zur Route `/routes/{id}` geleitet. |
+| Status | Offen |
+
+## PR-006 – Begehung im Profil sichtbar
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | PR-005 wurde erfolgreich durchgeführt. |
+| Schritte | 1. `/profile` öffnen. 2. Abschnitt „Meine Begehungen“ prüfen. |
+| Erwartetes Ergebnis | Die gespeicherte Route erscheint in der Liste. Datum, Status, Begehungsart und Anzahl Versuche stimmen. |
+| Status | Offen |
+
+## PR-007 – Abbrechen im Formular
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Progress-Formular ist mit gültiger Route-ID geöffnet. |
+| Schritte | 1. „Abbrechen“ klicken. |
+| Erwartetes Ergebnis | User wird zurück zur Route `/routes/{id}` geleitet. Es wird nichts gespeichert. |
+| Status | Offen |
+
+## PR-008 – Backend-Fehler beim Speichern
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Backend liefert Fehler oder ist nicht erreichbar. |
+| Schritte | 1. Progress-Formular ausfüllen. 2. Backend stoppen oder Fehler provozieren. 3. Speichern klicken. |
+| Erwartetes Ergebnis | Es erscheint eine Fehlermeldung, z. B. „Begehung konnte nicht gespeichert werden.“ Button wird wieder benutzbar. |
+| Status | Offen |

--- a/docs/tests/routes.md
+++ b/docs/tests/routes.md
@@ -1,0 +1,86 @@
+# Manuelle Testfälle – Routes
+
+Bereich: **Routendetail, Community Grade und Safety Reports**
+
+Hinweis: Falls es in der UI keinen direkten Link zur Route gibt, kann die Routendetailseite direkt über `/routes/{id}` geöffnet werden.
+
+## RT-001 – Routendetail laden
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Es gibt eine gültige Route-ID. |
+| Schritte | 1. URL `http://localhost:4200/routes/{id}` öffnen. |
+| Erwartetes Ergebnis | Route wird angezeigt. Name, Sektor, Grad, Stil, Länge und Beschreibung werden korrekt dargestellt. |
+| Status | Offen |
+
+## RT-002 – Community Grade anzeigen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Für die Route gibt es Community-Grade-Daten. |
+| Schritte | 1. Routendetailseite öffnen. |
+| Erwartetes Ergebnis | Neben dem Routengrad wird „Community: ...“ angezeigt. Wenn kein Wert vorhanden ist, wird nichts Falsches angezeigt. |
+| Status | Offen |
+
+## RT-003 – Sicherheitsmeldungen leerer Zustand
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Für die Route gibt es keine offenen Sicherheitsmeldungen. |
+| Schritte | 1. Routendetailseite öffnen. 2. Abschnitt „Sicherheitsmeldungen“ prüfen. |
+| Erwartetes Ergebnis | Es erscheint „Keine offenen Sicherheitsmeldungen.“ |
+| Status | Offen |
+
+## RT-004 – Sicherheitsmeldung erstellen Button nur eingeloggt
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Route existiert. |
+| Schritte | 1. Ausloggen. 2. Routendetailseite öffnen. 3. Einloggen und Seite erneut öffnen. |
+| Erwartetes Ergebnis | Ohne Login ist der Button „+ Meldung erstellen“ nicht sichtbar. Mit Login ist der Button sichtbar. |
+| Status | Offen |
+
+## RT-005 – Sicherheitsmeldung erstellen
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Route existiert. |
+| Schritte | 1. Routendetailseite öffnen. 2. „+ Meldung erstellen“ klicken. 3. Text eingeben. 4. Schweregrad wählen. 5. „Meldung abschicken“ klicken. |
+| Erwartetes Ergebnis | Meldung wird gespeichert und direkt in der Liste angezeigt. Text und Schweregrad stimmen. |
+| Status | Offen |
+
+## RT-006 – Sicherheitsmeldung mit Bild kleiner als 5 MB
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Es gibt ein gültiges Bild kleiner als 5 MB. |
+| Schritte | 1. Report-Formular öffnen. 2. Text eingeben. 3. Bild hochladen. 4. Meldung abschicken. |
+| Erwartetes Ergebnis | Upload funktioniert. Report wird mit Bild angezeigt. |
+| Status | Offen |
+
+## RT-007 – Sicherheitsmeldung Bild größer als 5 MB
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Es gibt ein Bild größer als 5 MB. |
+| Schritte | 1. Report-Formular öffnen. 2. Bild größer als 5 MB auswählen. |
+| Erwartetes Ergebnis | Es erscheint „Bild darf maximal 5 MB groß sein.“ Report wird nicht automatisch abgeschickt. |
+| Status | Offen |
+
+## RT-008 – Begehung eintragen Link
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | User ist eingeloggt. Route existiert. |
+| Schritte | 1. Routendetailseite öffnen. 2. Auf „+ Begehung eintragen“ klicken. |
+| Erwartetes Ergebnis | Formular `/progress/new` wird geöffnet. Query-Parameter `routeId` und `routeName` sind gesetzt. |
+| Status | Offen |
+
+## RT-009 – Route nicht vorhanden
+
+| Feld | Beschreibung |
+|---|---|
+| Voraussetzung | Backend läuft. Route-ID existiert nicht, z. B. `999999`. |
+| Schritte | 1. URL `/routes/999999` öffnen. |
+| Erwartetes Ergebnis | Es erscheint „Route konnte nicht geladen werden.“ |
+| Status | Offen |

--- a/docs/tests/test-protocol-template.md
+++ b/docs/tests/test-protocol-template.md
@@ -1,0 +1,85 @@
+# Testprotokoll – Manuelle Tests
+
+Projekt: **ClimbConnect**  
+User Story: **#25 Manuelle Testfälle definieren**
+
+## Testlauf
+
+| Feld | Wert |
+|---|---|
+| Datum |  |
+| Tester |  |
+| Browser |  |
+| Frontend-Version / Branch |  |
+| Backend-Version / Branch |  |
+| Testumgebung | lokal |
+
+## Ergebnisübersicht
+
+| Bereich | Anzahl OK | Anzahl Fehler | Anzahl Blockiert | Notiz |
+|---|---:|---:|---:|---|
+| Areas |  |  |  |  |
+| Routes |  |  |  |  |
+| Progress |  |  |  |  |
+| Appointments |  |  |  |  |
+| Comments |  |  |  |  |
+
+## Einzelne Testergebnisse
+
+| Test-ID | Status | Notiz / Fehlerbeschreibung |
+|---|---|---|
+| AR-001 | Offen |  |
+| AR-002 | Offen |  |
+| AR-003 | Offen |  |
+| AR-004 | Offen |  |
+| AR-005 | Offen |  |
+| AR-006 | Offen |  |
+| AR-007 | Offen |  |
+| AR-008 | Offen |  |
+| AR-009 | Offen |  |
+| AR-010 | Offen |  |
+| RT-001 | Offen |  |
+| RT-002 | Offen |  |
+| RT-003 | Offen |  |
+| RT-004 | Offen |  |
+| RT-005 | Offen |  |
+| RT-006 | Offen |  |
+| RT-007 | Offen |  |
+| RT-008 | Offen |  |
+| RT-009 | Offen |  |
+| PR-001 | Offen |  |
+| PR-002 | Offen |  |
+| PR-003 | Offen |  |
+| PR-004 | Offen |  |
+| PR-005 | Offen |  |
+| PR-006 | Offen |  |
+| PR-007 | Offen |  |
+| PR-008 | Offen |  |
+| AP-001 | Offen |  |
+| AP-002 | Offen |  |
+| AP-003 | Offen |  |
+| AP-004 | Offen |  |
+| AP-005 | Offen |  |
+| AP-006 | Offen |  |
+| AP-007 | Offen |  |
+| AP-008 | Offen |  |
+| AP-009 | Offen |  |
+| AP-010 | Offen |  |
+| AP-011 | Offen |  |
+| CM-001 | Offen |  |
+| CM-002 | Offen |  |
+| CM-003 | Offen |  |
+| CM-004 | Offen |  |
+| CM-005 | Offen |  |
+| CM-006 | Offen |  |
+| CM-007 | Offen |  |
+| CM-008 | Offen |  |
+| CM-009 | Offen |  |
+
+## Gefundene Fehler
+
+| Nr. | Test-ID | Beschreibung | Screenshot / Hinweis | Priorität |
+|---|---|---|---|---|
+| 1 |  |  |  |  |
+| 2 |  |  |  |  |
+| 3 |  |  |  |  |


### PR DESCRIPTION
## Änderungen

- Manuelle Testfälle für Issue #25 erstellt
- Testfälle für Areas, Routes, Progress, Appointments und Comments hinzugefügt
- Testprotokoll-Vorlage ergänzt

## Erfüllt

- Testfälle dokumentiert in docs/tests/
- Testfälle für Areas, Routes, Progress, Appointments, Comments vorhanden

Closes #25