### PR TITLE
fix: Kommentar-Button und Gradskala beheben (closes #154, #155)

### DIFF
--- a/frontend/src/app/features/areas/area-detail.component.css
+++ b/frontend/src/app/features/areas/area-detail.component.css
@@ -625,3 +625,49 @@
   color: #b91c1c;
   font-weight: 850;
 }
+
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 14px 0;
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  background: #f8fafc;
+}
+
+.comment-form textarea {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.comment-form-error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.comment-submit {
+  align-self: flex-end;
+  padding: 9px 18px;
+  border: none;
+  border-radius: 10px;
+  background: #111827;
+  color: #ffffff;
+  font-weight: 950;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.comment-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/app/features/areas/area-detail.component.html
+++ b/frontend/src/app/features/areas/area-detail.component.html
@@ -258,11 +258,31 @@
             </div>
 
             @if (isLoggedIn()) {
-              <button type="button" class="comment-button">
-                Schreiben
+              <button type="button" class="comment-button" (click)="showCommentForm = !showCommentForm">
+                {{ showCommentForm ? 'Abbrechen' : 'Schreiben' }}
               </button>
             }
           </div>
+
+          @if (showCommentForm) {
+            <div class="comment-form">
+              <textarea
+                [(ngModel)]="commentText"
+                placeholder="Dein Kommentar zu diesem Gebiet..."
+                rows="3">
+              </textarea>
+              @if (commentError) {
+                <p class="comment-form-error">{{ commentError }}</p>
+              }
+              <button
+                type="button"
+                class="comment-submit"
+                [disabled]="commentSending || !commentText.trim()"
+                (click)="submitComment()">
+                {{ commentSending ? 'Wird gespeichert...' : 'Absenden' }}
+              </button>
+            </div>
+          }
 
           @if (comments.length === 0) {
 

--- a/frontend/src/app/features/areas/area-detail.component.ts
+++ b/frontend/src/app/features/areas/area-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import {
   Area,
   AreaComment,
@@ -10,6 +11,7 @@ import {
   Sector
 } from '../../../services/areas.service';
 import { AuthService } from '../../../services/auth.service';
+import { UserService } from '../../../services/user.service';
 
 interface SectorWithRoutes extends Sector {
   expanded: boolean;
@@ -20,7 +22,7 @@ interface SectorWithRoutes extends Sector {
 @Component({
   selector: 'app-area-detail',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, RouterLink, FormsModule],
   templateUrl: './area-detail.component.html',
   styleUrl: './area-detail.component.css'
 })
@@ -29,6 +31,7 @@ export class AreaDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private areasService = inject(AreasService);
   private authService = inject(AuthService);
+  private userService = inject(UserService);
 
   area?: Area;
   sectors: SectorWithRoutes[] = [];
@@ -41,8 +44,15 @@ export class AreaDetailComponent implements OnInit {
   deletingAppointmentId: number | null = null;
   appointmentActionError = '';
 
+  gradeScale = 'french';
+
   loading = true;
   errorMessage = '';
+
+  showCommentForm = false;
+  commentText = '';
+  commentSending = false;
+  commentError = '';
 
   ngOnInit(): void {
     this.currentUserId = this.authService.getUserId();
@@ -52,6 +62,13 @@ export class AreaDetailComponent implements OnInit {
       this.errorMessage = 'Ungültige Area-ID.';
       this.loading = false;
       return;
+    }
+
+    if (this.authService.isAuthenticated()) {
+      this.userService.getMe().subscribe({
+        next: (data) => { this.gradeScale = data.preferredGradeScale ?? 'french'; },
+        error: () => {}
+      });
     }
 
     this.loadAreaDetails(id);
@@ -106,7 +123,7 @@ export class AreaDetailComponent implements OnInit {
   loadRoutesForSector(sector: SectorWithRoutes): void {
     sector.loadingRoutes = true;
 
-    this.areasService.getRoutesBySector(sector.id, 'french').subscribe({
+    this.areasService.getRoutesBySector(sector.id, this.gradeScale).subscribe({
       next: (routes) => {
         sector.routes = routes;
         sector.loadingRoutes = false;
@@ -169,6 +186,25 @@ export class AreaDetailComponent implements OnInit {
         appointment.participantCount = Math.max((appointment.participantCount ?? 1) - 1, 0);
       },
       error: () => {}
+    });
+  }
+
+  submitComment(): void {
+    if (!this.commentText.trim() || !this.area) return;
+    this.commentSending = true;
+    this.commentError = '';
+
+    this.areasService.addAreaComment(this.area.id, this.commentText.trim()).subscribe({
+      next: (comment: AreaComment) => {
+        this.comments = [comment, ...this.comments];
+        this.commentText = '';
+        this.commentSending = false;
+        this.showCommentForm = false;
+      },
+      error: () => {
+        this.commentError = 'Kommentar konnte nicht gespeichert werden.';
+        this.commentSending = false;
+      }
     });
   }
 }

--- a/frontend/src/app/features/routes/route-detail.component.ts
+++ b/frontend/src/app/features/routes/route-detail.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { AreasService, ClimbingRoute, RouteComment, SafetyReport } from '../../../services/areas.service';
 import { AuthService } from '../../../services/auth.service';
+import { UserService } from '../../../services/user.service';
 
 @Component({
   selector: 'app-route-detail',
@@ -39,11 +40,14 @@ export class RouteDetailComponent implements OnInit {
   reportError = '';
   reportSuccess = false;
 
+  gradeScale = 'french';
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private areasService: AreasService,
-    private authService: AuthService
+    private authService: AuthService,
+    private userService: UserService
   ) {}
 
   ngOnInit(): void {
@@ -54,7 +58,31 @@ export class RouteDetailComponent implements OnInit {
       return;
     }
 
-    this.areasService.getRouteById(id, 'french').subscribe({
+    if (this.authService.isAuthenticated()) {
+      this.userService.getMe().subscribe({
+        next: (data) => {
+          this.gradeScale = data.preferredGradeScale ?? 'french';
+          this.loadRoute(id);
+        },
+        error: () => this.loadRoute(id)
+      });
+    } else {
+      this.loadRoute(id);
+    }
+
+    this.areasService.getRouteComments(id).subscribe({
+      next: (c) => { this.comments = c; },
+      error: () => {}
+    });
+
+    this.areasService.getRouteReports(id).subscribe({
+      next: (r) => { this.reports = r; },
+      error: () => {}
+    });
+  }
+
+  private loadRoute(id: number): void {
+    this.areasService.getRouteById(id, this.gradeScale).subscribe({
       next: (r) => {
         this.route = r;
         this.loading = false;
@@ -65,18 +93,8 @@ export class RouteDetailComponent implements OnInit {
       }
     });
 
-    this.areasService.getCommunityGrade(id, 'french').subscribe({
+    this.areasService.getCommunityGrade(id, this.gradeScale).subscribe({
       next: (data) => { this.communityGrade = data?.communityGrade ?? null; },
-      error: () => {}
-    });
-
-    this.areasService.getRouteComments(id).subscribe({
-      next: (c) => { this.comments = c; },
-      error: () => {}
-    });
-
-    this.areasService.getRouteReports(id).subscribe({
-      next: (r) => { this.reports = r; },
       error: () => {}
     });
   }

--- a/frontend/src/services/areas.service.ts
+++ b/frontend/src/services/areas.service.ts
@@ -201,6 +201,10 @@ export class AreasService {
     return this.http.get<RouteComment[]>(`${this.apiUrl}/routes/${routeId}/comments`);
   }
 
+  addAreaComment(areaId: number, text: string, photoUrl?: string | null): Observable<any> {
+    return this.http.post(`${this.apiUrl}/areas/${areaId}/comments`, { text, photoUrl });
+  }
+
   addRouteComment(routeId: number, text: string, photoUrl?: string | null): Observable<any> {
     return this.http.post(`${this.apiUrl}/routes/${routeId}/comments`, { text, photoUrl });
   }


### PR DESCRIPTION
## Was wurde gefixt

- **#154** — Kommentar-Button in AreaDetail hatte keine Funktion → Button öffnet jetzt ein Inline-Formular, Kommentar wird per API gespeichert
- **#155** — Bevorzugte Gradskala wurde ignoriert (immer Französisch) → `UserService.getMe()` wird beim Laden aufgerufen, gespeicherte Skala des Users wird verwendet (AreaDetail + RouteDetail)

## Hinweis

Bugs #152 und #153 wurden in der Zwischenzeit bereits vom Kollegen auf main gefixt.

## Geänderte Dateien

- `frontend/src/services/areas.service.ts` — `addAreaComment()` hinzugefügt
- `frontend/src/app/features/areas/area-detail.component.ts` — UserService, gradeScale, Kommentar-Formular-Logik, FormsModule
- `frontend/src/app/features/areas/area-detail.component.html` — Kommentar-Button verknüpft, Inline-Formular
- `frontend/src/app/features/areas/area-detail.component.css` — Styles für Kommentar-Formular
- `frontend/src/app/features/routes/route-detail.component.ts` — UserService, gradeScale aus Profil