### PR TITLE
fix: Bugs + Kommentar löschen + Passwort ändern (closes #155, #163, #166)

### DIFF
--- a/backend/ClimbConnect.API/Dtos/ChangePasswordDto.cs
+++ b/backend/ClimbConnect.API/Dtos/ChangePasswordDto.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ClimbConnect.API.Dtos;
+
+/// <summary>Payload zum Ändern des eigenen Passworts.</summary>
+public record ChangePasswordDto(
+    [Required] string CurrentPassword,
+    [Required][MinLength(8)][MaxLength(100)] string NewPassword
+);

--- a/backend/ClimbConnect.API/Extensions/UserEndpoints.cs
+++ b/backend/ClimbConnect.API/Extensions/UserEndpoints.cs
@@ -146,6 +146,26 @@ public static class UserEndpoints
         .WithName("GetUserProfile")
         .WithTags("Users");
 
+        // Passwort ändern
+        app.MapPut("/api/users/me/password", async (ChangePasswordDto dto, ClaimsPrincipal user, AppDbContext db) =>
+        {
+            if (!int.TryParse(user.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
+                return Results.Unauthorized();
+
+            var u = await db.Users.FindAsync(userId);
+            if (u is null) return Results.NotFound();
+
+            if (!BCrypt.Net.BCrypt.Verify(dto.CurrentPassword, u.PasswordHash))
+                return Results.BadRequest(new { error = "Aktuelles Passwort ist falsch" });
+
+            u.PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.NewPassword);
+            await db.SaveChangesAsync();
+            return Results.NoContent();
+        })
+        .WithName("ChangePassword")
+        .WithTags("Users")
+        .RequireAuthorization("User");
+
         // Benutzerliste (öffentlich)
         app.MapGet("/api/users", async (AppDbContext db) =>
         {

--- a/frontend/src/app/features/areas/area-detail.component.html
+++ b/frontend/src/app/features/areas/area-detail.component.html
@@ -301,18 +301,28 @@
                     @if (comment.authorPhotoUrl) {
                       <img [src]="comment.authorPhotoUrl" [alt]="comment.authorName || 'User'">
                     } @else {
-                      <span>{{ (comment.authorName || 'U').charAt(0) }}</span>
+                      <span>{{ (comment.user?.username || comment.authorName || 'U').charAt(0) }}</span>
                     }
 
                     <div>
-                      <strong>{{ comment.authorName || 'Unbekannter User' }}</strong>
-                      @if (comment.createdAt) {
-                        <small>{{ comment.createdAt | date:'dd.MM.yyyy' }}</small>
+                      <strong>{{ comment.user?.username || comment.authorName || 'Unbekannter User' }}</strong>
+                      @if (comment.createdAtUtc || comment.createdAt) {
+                        <small>{{ (comment.createdAtUtc || comment.createdAt) | date:'dd.MM.yyyy' }}</small>
                       }
                     </div>
                   </div>
 
                   <p>{{ comment.text }}</p>
+
+                  @if (isOwnComment(comment)) {
+                    <button
+                      type="button"
+                      class="btn-delete-comment"
+                      [disabled]="deletingCommentId === comment.id"
+                      (click)="deleteComment(comment.id)">
+                      {{ deletingCommentId === comment.id ? 'Löscht...' : 'Löschen' }}
+                    </button>
+                  }
 
                 </article>
               }

--- a/frontend/src/app/features/areas/area-detail.component.ts
+++ b/frontend/src/app/features/areas/area-detail.component.ts
@@ -53,6 +53,7 @@ export class AreaDetailComponent implements OnInit {
   commentText = '';
   commentSending = false;
   commentError = '';
+  deletingCommentId: number | null = null;
 
   ngOnInit(): void {
     this.currentUserId = this.authService.getUserId();
@@ -186,6 +187,22 @@ export class AreaDetailComponent implements OnInit {
         appointment.participantCount = Math.max((appointment.participantCount ?? 1) - 1, 0);
       },
       error: () => {}
+    });
+  }
+
+  isOwnComment(comment: { userId?: number }): boolean {
+    return !!this.currentUserId && comment.userId === this.currentUserId;
+  }
+
+  deleteComment(commentId: number): void {
+    if (!window.confirm('Kommentar wirklich löschen?')) return;
+    this.deletingCommentId = commentId;
+    this.areasService.deleteComment(commentId).subscribe({
+      next: () => {
+        this.comments = this.comments.filter(c => c.id !== commentId);
+        this.deletingCommentId = null;
+      },
+      error: () => { this.deletingCommentId = null; }
     });
   }
 

--- a/frontend/src/app/features/routes/route-detail.component.html
+++ b/frontend/src/app/features/routes/route-detail.component.html
@@ -104,12 +104,21 @@
 
       @for (comment of comments; track comment.id) {
         <div class="comment-item">
-          <div class="comment-author">{{ comment.authorName }}</div>
+          <div class="comment-author">{{ comment.user?.username || comment.authorName || 'Unbekannter User' }}</div>
           <p>{{ comment.text }}</p>
           @if (comment.photoUrl) {
             <img [src]="comment.photoUrl" alt="Kommentar Foto" class="comment-photo">
           }
           <small>{{ comment.createdAtUtc | date:'dd.MM.yyyy' }}</small>
+          @if (isOwnComment(comment)) {
+            <button
+              type="button"
+              class="btn-delete-comment"
+              [disabled]="deletingCommentId === comment.id"
+              (click)="deleteComment(comment.id)">
+              {{ deletingCommentId === comment.id ? 'Löscht...' : 'Löschen' }}
+            </button>
+          }
         </div>
       }
     </section>

--- a/frontend/src/app/features/routes/route-detail.component.ts
+++ b/frontend/src/app/features/routes/route-detail.component.ts
@@ -41,6 +41,8 @@ export class RouteDetailComponent implements OnInit {
   reportSuccess = false;
 
   gradeScale = 'french';
+  currentUserId: number | null = null;
+  deletingCommentId: number | null = null;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -51,6 +53,7 @@ export class RouteDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.currentUserId = this.authService.getUserId();
     const id = Number(this.activatedRoute.snapshot.paramMap.get('id'));
     if (!id) {
       this.errorMessage = 'Ungültige Routen-ID.';
@@ -105,6 +108,22 @@ export class RouteDetailComponent implements OnInit {
 
   get routeId(): number {
     return Number(this.activatedRoute.snapshot.paramMap.get('id'));
+  }
+
+  isOwnComment(comment: { userId?: number }): boolean {
+    return !!this.currentUserId && comment.userId === this.currentUserId;
+  }
+
+  deleteComment(commentId: number): void {
+    if (!window.confirm('Kommentar wirklich löschen?')) return;
+    this.deletingCommentId = commentId;
+    this.areasService.deleteComment(commentId).subscribe({
+      next: () => {
+        this.comments = this.comments.filter(c => c.id !== commentId);
+        this.deletingCommentId = null;
+      },
+      error: () => { this.deletingCommentId = null; }
+    });
   }
 
   severityClass(severity: string): string {

--- a/frontend/src/app/features/users/public-profile.component.ts
+++ b/frontend/src/app/features/users/public-profile.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { UserService, PublicProfile } from '../../../services/user.service';
+import { AuthService } from '../../../services/auth.service';
 
 @Component({
   selector: 'app-public-profile',
@@ -18,7 +19,8 @@ export class PublicProfileComponent implements OnInit {
 
   constructor(
     private activatedRoute: ActivatedRoute,
-    private userService: UserService
+    private userService: UserService,
+    private authService: AuthService
   ) {}
 
   ngOnInit(): void {
@@ -29,7 +31,18 @@ export class PublicProfileComponent implements OnInit {
       return;
     }
 
-    this.userService.getPublicProfile(id, 'french').subscribe({
+    if (this.authService.isAuthenticated()) {
+      this.userService.getMe().subscribe({
+        next: (data) => this.loadProfile(id, data.preferredGradeScale ?? 'french'),
+        error: () => this.loadProfile(id, 'french')
+      });
+    } else {
+      this.loadProfile(id, 'french');
+    }
+  }
+
+  private loadProfile(id: number, scale: string): void {
+    this.userService.getPublicProfile(id, scale).subscribe({
       next: (data) => {
         this.profile = data;
         this.loading = false;

--- a/frontend/src/app/user-profile/user-profile.component.html
+++ b/frontend/src/app/user-profile/user-profile.component.html
@@ -64,6 +64,40 @@
       </div>
     </section>
 
+    <section class="profile-card password-card">
+      <h2>Passwort ändern</h2>
+
+      <div class="form-group">
+        <label>Aktuelles Passwort</label>
+        <input type="password" [(ngModel)]="passwordForm.current" autocomplete="current-password">
+      </div>
+      <div class="form-group">
+        <label>Neues Passwort</label>
+        <input type="password" [(ngModel)]="passwordForm.newPw" autocomplete="new-password">
+      </div>
+      <div class="form-group">
+        <label>Neues Passwort bestätigen</label>
+        <input type="password" [(ngModel)]="passwordForm.confirm" autocomplete="new-password">
+      </div>
+
+      @if (passwordSuccess) {
+        <p class="success-msg">Passwort erfolgreich geändert!</p>
+      }
+      @if (passwordError) {
+        <p class="error-msg">{{ passwordError }}</p>
+      }
+
+      <div class="button-row">
+        <button
+          type="button"
+          class="save-button"
+          [disabled]="!passwordForm.current || !passwordForm.newPw || !passwordForm.confirm"
+          (click)="changePassword()">
+          Passwort ändern
+        </button>
+      </div>
+    </section>
+
     <aside class="profile-card statistics-card">
       <h2>Statistiken</h2>
 

--- a/frontend/src/app/user-profile/user-profile.component.ts
+++ b/frontend/src/app/user-profile/user-profile.component.ts
@@ -56,6 +56,10 @@ export class UserProfileComponent implements OnInit, AfterViewInit {
   saveSuccess = false;
   saveError = '';
 
+  passwordForm = { current: '', newPw: '', confirm: '' };
+  passwordSuccess = false;
+  passwordError = '';
+
   constructor(
     private userService: UserService,
     private areasService: AreasService
@@ -247,6 +251,30 @@ export class UserProfileComponent implements OnInit, AfterViewInit {
             }
           }
         }
+      }
+    });
+  }
+
+  changePassword(): void {
+    this.passwordSuccess = false;
+    this.passwordError   = '';
+
+    if (this.passwordForm.newPw !== this.passwordForm.confirm) {
+      this.passwordError = 'Die neuen Passwörter stimmen nicht überein.';
+      return;
+    }
+    if (this.passwordForm.newPw.length < 8) {
+      this.passwordError = 'Das neue Passwort muss mindestens 8 Zeichen lang sein.';
+      return;
+    }
+
+    this.userService.changePassword(this.passwordForm.current, this.passwordForm.newPw).subscribe({
+      next: () => {
+        this.passwordSuccess = true;
+        this.passwordForm = { current: '', newPw: '', confirm: '' };
+      },
+      error: (err) => {
+        this.passwordError = err?.error?.error ?? 'Passwort konnte nicht geändert werden.';
       }
     });
   }

--- a/frontend/src/services/areas.service.ts
+++ b/frontend/src/services/areas.service.ts
@@ -42,18 +42,23 @@ export interface ClimbingRoute {
 
 export interface RouteComment {
   id: number;
+  userId?: number;
   text: string;
   authorName?: string | null;
+  user?: { username?: string | null };
   photoUrl?: string | null;
   createdAtUtc?: string | null;
 }
 
 export interface AreaComment {
   id: number;
+  userId?: number;
   text: string;
   authorName?: string | null;
+  user?: { username?: string | null };
   authorPhotoUrl?: string | null;
   createdAt?: string | null;
+  createdAtUtc?: string | null;
 }
 
 export interface SafetyReport {
@@ -219,6 +224,10 @@ export class AreasService {
 
   addRouteComment(routeId: number, text: string, photoUrl?: string | null): Observable<any> {
     return this.http.post(`${this.apiUrl}/routes/${routeId}/comments`, { text, photoUrl });
+  }
+
+  deleteComment(commentId: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/comments/${commentId}`);
   }
 
   getRouteReports(routeId: number): Observable<SafetyReport[]> {

--- a/frontend/src/services/user.service.ts
+++ b/frontend/src/services/user.service.ts
@@ -57,6 +57,11 @@ export class UserService {
     return this.http.get<PublicProfile>(`${this.apiUrl}/api/users/${userId}/profile?scale=${scale}`);
   }
 
+  /// Passwort ändern (PUT /api/users/me/password)
+  changePassword(currentPassword: string, newPassword: string) {
+    return this.http.put(`${this.apiUrl}/api/users/me/password`, { currentPassword, newPassword });
+  }
+
   /// Öffentliche User-Liste abrufen (GET /api/users)
   getUsers() {
     return this.http.get<UserListItem[]>(`${this.apiUrl}/api/users`);


### PR DESCRIPTION
## Was wurde gemacht

### Bug #155 — Bevorzugte Gradskala in öffentlichen Profilen
`PublicProfileComponent` hat bisher `'french'` hardcoded. Jetzt wird bei eingeloggten Usern zuerst `GET /api/users/me` aufgerufen und die `preferredGradeScale` verwendet. Konsistent mit `AreaDetailComponent` und `RouteDetailComponent`.

### Feature #163 — Kommentar löschen
- Backend: `DELETE /api/comments/{id}` war bereits vorhanden (User darf nur eigene Kommentare löschen)
- Frontend `AreasService`: `deleteComment()` Methode hinzugefügt
- `AreaDetailComponent`: Delete-Button für eigene Kommentare
- `RouteDetailComponent`: Delete-Button für eigene Kommentare
- Bonus: Kommentar-Autoren werden jetzt korrekt über `comment.user?.username` angezeigt

### Feature #166 — Passwort ändern
- Backend: `PUT /api/users/me/password` mit `ChangePasswordDto` (currentPassword, newPassword)
- Prüft aktuelles Passwort mit BCrypt.Verify, setzt neues Hash
- Frontend `UserService`: `changePassword()` Methode
- Profil-Seite: neues Passwort-Formular mit Bestätigungsfeld und Client-seitiger Validierung

### Bereits in vorherigen Commits geschlossen (diese Session)
- #152 Datum-Format war bereits gefixt
- #153 Routen-Links waren bereits gefixt
- #164 Paginierung — in vorherigem PR
- #165 Auto-Logout — in vorherigem PR

## Test plan
- [ ] Profil-Seite → Passwort-Formular sichtbar
- [ ] Falsches aktuelles Passwort → Fehlermeldung "Aktuelles Passwort ist falsch"
- [ ] Neues Passwort ≠ Bestätigung → Client-Fehlermeldung
- [ ] Erfolgreich ändern → Login mit neuem Passwort funktioniert
- [ ] Kommentar schreiben → "Löschen"-Button erscheint nur beim eigenen Kommentar
- [ ] Löschen → Kommentar verschwindet aus der Liste