### PR TITLE
feat: Termin-Detail, Kletterer-Suche, Admin-Reports (closes #159, #161, #162)

### DIFF
--- a/frontend/src/app/admin/admin.component.html
+++ b/frontend/src/app/admin/admin.component.html
@@ -13,6 +13,7 @@
     <button [class.active]="activeTab === 'areas'"   (click)="setTab('areas')">Gebiete</button>
     <button [class.active]="activeTab === 'sectors'" (click)="setTab('sectors')">Sektoren</button>
     <button [class.active]="activeTab === 'routes'"  (click)="setTab('routes')">Routen</button>
+    <button [class.active]="activeTab === 'reports'" (click)="setTab('reports')">Reports</button>
   </div>
 
   <!-- ══════════════════════════════════════════════════════════════════════ -->
@@ -270,6 +271,60 @@
 
       }
 
+    </section>
+  }
+
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  <!-- TAB: REPORTS                                                           -->
+  <!-- ══════════════════════════════════════════════════════════════════════ -->
+  @if (activeTab === 'reports') {
+    <section class="tab-content">
+      <div class="section-header">
+        <h2>Safety Reports</h2>
+        <label class="toggle-label">
+          <input type="checkbox" [(ngModel)]="showResolvedReports">
+          Erledigte anzeigen
+        </label>
+      </div>
+
+      @if (visibleReports.length === 0) {
+        <p class="empty-hint">Keine offenen Reports vorhanden.</p>
+      } @else {
+        @for (report of visibleReports; track report.id) {
+          <div class="report-item" [class]="severityClass(report.severity)" [class.resolved]="report.status === 'Resolved'">
+            <div class="report-header">
+              <span class="report-severity-badge">{{ report.severity }}</span>
+              <span class="report-status" [class.status-resolved]="report.status === 'Resolved'">
+                {{ report.status === 'Resolved' ? 'Erledigt' : 'Offen' }}
+              </span>
+              <small>{{ report.createdAtUtc | date:'dd.MM.yyyy HH:mm' }}</small>
+            </div>
+
+            <p class="report-text">{{ report.text }}</p>
+
+            @if (report.user?.username) {
+              <small class="report-author">Gemeldet von: {{ report.user.username }}</small>
+            }
+
+            @if (report.routeId) {
+              <small>Route-ID: {{ report.routeId }}</small>
+            }
+            @if (report.areaId) {
+              <small>Gebiet-ID: {{ report.areaId }}</small>
+            }
+
+            @if (report.photoUrl) {
+              <img [src]="report.photoUrl" alt="Report Foto" class="report-photo">
+            }
+
+            @if (report.status !== 'Resolved') {
+              <button class="btn-resolve" (click)="resolveReport(report)">
+                ✓ Als erledigt markieren
+              </button>
+            }
+          </div>
+        }
+      }
     </section>
   }
 

--- a/frontend/src/app/admin/admin.component.ts
+++ b/frontend/src/app/admin/admin.component.ts
@@ -14,7 +14,7 @@ export class AdminComponent implements OnInit {
 
   private adminService = inject(AdminService);
 
-  activeTab: 'areas' | 'sectors' | 'routes' = 'areas';
+  activeTab: 'areas' | 'sectors' | 'routes' | 'reports' = 'areas';
 
   // ── Gebiete ────────────────────────────────────────────────────────────────
   areas: any[] = [];
@@ -47,10 +47,11 @@ export class AdminComponent implements OnInit {
     this.loadAreas();
   }
 
-  setTab(tab: 'areas' | 'sectors' | 'routes'): void {
+  setTab(tab: 'areas' | 'sectors' | 'routes' | 'reports'): void {
     this.activeTab = tab;
     this.clearMessages();
     this.resetForms();
+    if (tab === 'reports') this.loadReports();
   }
 
   // ── Gebiete ────────────────────────────────────────────────────────────────
@@ -250,6 +251,44 @@ export class AdminComponent implements OnInit {
       },
       error: (err) => { this.errorMsg = err?.error?.error ?? 'Fehler beim Löschen.'; }
     });
+  }
+
+  // ── Reports ────────────────────────────────────────────────────────────────
+
+  reports: any[] = [];
+  showResolvedReports = false;
+
+  loadReports(): void {
+    this.clearMessages();
+    this.adminService.getReports().subscribe({
+      next: (data) => { this.reports = data; },
+      error: () => { this.errorMsg = 'Reports konnten nicht geladen werden.'; }
+    });
+  }
+
+  resolveReport(report: any): void {
+    this.clearMessages();
+    this.adminService.resolveReport(report.id).subscribe({
+      next: () => {
+        report.status = 'Resolved';
+        this.successMsg = 'Report als erledigt markiert.';
+      },
+      error: () => { this.errorMsg = 'Fehler beim Aktualisieren des Reports.'; }
+    });
+  }
+
+  get visibleReports(): any[] {
+    return this.showResolvedReports
+      ? this.reports
+      : this.reports.filter(r => r.status !== 'Resolved');
+  }
+
+  severityClass(severity: string): string {
+    switch (severity?.toLowerCase()) {
+      case 'high':   return 'severity-high';
+      case 'medium': return 'severity-medium';
+      default:       return 'severity-low';
+    }
   }
 
   // ── Datenbank zurücksetzen ─────────────────────────────────────────────────

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { AppointmentFormComponent } from './features/appointments/appointment-fo
 import { RouteDetailComponent } from './features/routes/route-detail.component';
 import { PublicProfileComponent } from './features/users/public-profile.component';
 import { ProgressFormComponent } from './features/progress/progress-form.component';
+import { ClimbersPage } from './features/climbers/climbers-page';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
@@ -20,6 +21,8 @@ export const routes: Routes = [
   { path: 'home', component: HomePageComponent },
 
   { path: 'areas', component: AreasPageComponent },
+
+  { path: 'climbers', component: ClimbersPage },
 
   {
     path: 'areas/:id/appointments/new',

--- a/frontend/src/app/features/areas/area-detail.component.html
+++ b/frontend/src/app/features/areas/area-detail.component.html
@@ -192,9 +192,9 @@
             <div class="appointment-list">
               @for (appointment of appointments; track appointment.id) {
                 <article class="appointment-card">
-                  <div class="appointment-topline">
+                  <div class="appointment-topline" (click)="toggleAppointmentDetail(appointment.id)" style="cursor:pointer">
                     <h3>{{ appointment.title }}</h3>
-                    <span>{{ appointment.participantCount ?? 0 }} TN</span>
+                    <span>{{ appointment.participantCount ?? 0 }} TN {{ expandedAppointmentId === appointment.id ? '▲' : '▼' }}</span>
                   </div>
 
                   <p class="appointment-date">
@@ -207,6 +207,30 @@
 
                   @if (appointment.meetingPoint) {
                     <p class="appointment-meeting">Treffpunkt: {{ appointment.meetingPoint }}</p>
+                  }
+
+                  @if (expandedAppointmentId === appointment.id) {
+                    @let detail = appointmentDetails[appointment.id];
+                    @if (detail) {
+                      <div class="appointment-detail">
+                        @if (detail.description) {
+                          <p class="appointment-description">{{ detail.description }}</p>
+                        }
+                        @if (detail.averageGrade) {
+                          <p class="appointment-avg-grade">Ø Grad der Gruppe: <strong>{{ detail.averageGrade }}</strong></p>
+                        }
+                        @if (detail.participants?.length > 0) {
+                          <div class="participant-list">
+                            <strong>Teilnehmer:</strong>
+                            @for (p of detail.participants; track p.userId) {
+                              <span class="participant-chip">{{ p.username }}</span>
+                            }
+                          </div>
+                        }
+                      </div>
+                    } @else {
+                      <p class="loading-detail">Lädt...</p>
+                    }
                   }
 
                   @if (isOwnAppointment(appointment)) {
@@ -305,7 +329,13 @@
                     }
 
                     <div>
-                      <strong>{{ comment.user?.username || comment.authorName || 'Unbekannter User' }}</strong>
+                      @if (comment.user?.id) {
+                        <a [routerLink]="['/users', comment.user!.id]" class="author-link">
+                          {{ comment.user?.username || comment.authorName || 'Unbekannter User' }}
+                        </a>
+                      } @else {
+                        <strong>{{ comment.user?.username || comment.authorName || 'Unbekannter User' }}</strong>
+                      }
                       @if (comment.createdAtUtc || comment.createdAt) {
                         <small>{{ (comment.createdAtUtc || comment.createdAt) | date:'dd.MM.yyyy' }}</small>
                       }

--- a/frontend/src/app/features/areas/area-detail.component.ts
+++ b/frontend/src/app/features/areas/area-detail.component.ts
@@ -44,6 +44,9 @@ export class AreaDetailComponent implements OnInit {
   deletingAppointmentId: number | null = null;
   appointmentActionError = '';
 
+  expandedAppointmentId: number | null = null;
+  appointmentDetails: { [id: number]: any } = {};
+
   gradeScale = 'french';
 
   loading = true;
@@ -188,6 +191,20 @@ export class AreaDetailComponent implements OnInit {
       },
       error: () => {}
     });
+  }
+
+  toggleAppointmentDetail(appointmentId: number): void {
+    if (this.expandedAppointmentId === appointmentId) {
+      this.expandedAppointmentId = null;
+      return;
+    }
+    this.expandedAppointmentId = appointmentId;
+    if (!this.appointmentDetails[appointmentId]) {
+      this.areasService.getAppointmentById(appointmentId, this.gradeScale).subscribe({
+        next: (detail) => { this.appointmentDetails[appointmentId] = detail; },
+        error: () => {}
+      });
+    }
   }
 
   isOwnComment(comment: { userId?: number }): boolean {

--- a/frontend/src/app/features/climbers/climbers-page.html
+++ b/frontend/src/app/features/climbers/climbers-page.html
@@ -1,1 +1,37 @@
-<p>climbers-page works!</p>
+<section class="climbers-page">
+
+  <div class="page-header">
+    <h1>Kletterer</h1>
+    <p>Suche andere Kletterer und sieh ihre letzten Begehungen.</p>
+  </div>
+
+  <div class="search-bar">
+    <input
+      type="text"
+      [(ngModel)]="searchTerm"
+      placeholder="Benutzername suchen..."
+      class="search-input">
+  </div>
+
+  @if (loading) {
+    <p class="loading-msg">Wird geladen...</p>
+  } @else if (errorMessage) {
+    <p class="error-msg">{{ errorMessage }}</p>
+  } @else if (filteredUsers.length === 0) {
+    <p class="empty-hint">Kein Benutzer gefunden.</p>
+  } @else {
+    <div class="user-list">
+      @for (user of filteredUsers; track user.id) {
+        <a class="user-card" [routerLink]="['/users', user.id]">
+          <div class="user-avatar">{{ user.username.charAt(0).toUpperCase() }}</div>
+          <div class="user-info">
+            <strong>{{ user.username }}</strong>
+            <small>Dabei seit {{ user.memberSince | date:'MMMM yyyy' : '' : 'de' }}</small>
+          </div>
+          <span class="profile-link">Profil ansehen →</span>
+        </a>
+      }
+    </div>
+  }
+
+</section>

--- a/frontend/src/app/features/climbers/climbers-page.ts
+++ b/frontend/src/app/features/climbers/climbers-page.ts
@@ -1,11 +1,41 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { UserService, UserListItem } from '../../../services/user.service';
 
 @Component({
   selector: 'app-climbers-page',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
   templateUrl: './climbers-page.html',
   styleUrl: './climbers-page.css',
 })
-export class ClimbersPage {
+export class ClimbersPage implements OnInit {
 
+  allUsers: UserListItem[] = [];
+  searchTerm = '';
+  loading = true;
+  errorMessage = '';
+
+  constructor(private userService: UserService) {}
+
+  ngOnInit(): void {
+    this.userService.getUsers().subscribe({
+      next: (users) => {
+        this.allUsers = users;
+        this.loading = false;
+      },
+      error: () => {
+        this.errorMessage = 'Benutzerliste konnte nicht geladen werden.';
+        this.loading = false;
+      }
+    });
+  }
+
+  get filteredUsers(): UserListItem[] {
+    const term = this.searchTerm.trim().toLowerCase();
+    if (!term) return this.allUsers;
+    return this.allUsers.filter(u => u.username.toLowerCase().includes(term));
+  }
 }

--- a/frontend/src/app/features/routes/route-detail.component.html
+++ b/frontend/src/app/features/routes/route-detail.component.html
@@ -104,7 +104,13 @@
 
       @for (comment of comments; track comment.id) {
         <div class="comment-item">
-          <div class="comment-author">{{ comment.user?.username || comment.authorName || 'Unbekannter User' }}</div>
+          <div class="comment-author">
+            @if (comment.user?.id) {
+              <a [routerLink]="['/users', comment.user!.id]">{{ comment.user?.username || comment.authorName || 'Unbekannter User' }}</a>
+            } @else {
+              {{ comment.user?.username || comment.authorName || 'Unbekannter User' }}
+            }
+          </div>
           <p>{{ comment.text }}</p>
           @if (comment.photoUrl) {
             <img [src]="comment.photoUrl" alt="Kommentar Foto" class="comment-photo">

--- a/frontend/src/app/menu/menu.component.html
+++ b/frontend/src/app/menu/menu.component.html
@@ -21,6 +21,13 @@
       Areas
     </a>
 
+    <a
+      routerLink="/climbers"
+      routerLinkActive="active"
+      class="action-item">
+      Kletterer
+    </a>
+
     @if (isAdmin) {
       <a
         routerLink="/admin"

--- a/frontend/src/services/admin.service.ts
+++ b/frontend/src/services/admin.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from '../environments/environment';
 
 @Injectable({
@@ -15,7 +16,7 @@ export class AdminService {
   // ── Gebiete ────────────────────────────────────────────────────────────────
 
   getAreas(): Observable<any[]> {
-    return this.http.get<any[]>(`${this.api}/areas`);
+    return this.http.get<{ items: any[] }>(`${this.api}/areas?pageSize=100`).pipe(map(r => r.items));
   }
 
   createArea(data: { name: string; location?: string | null; description?: string | null; imageUrl?: string | null }): Observable<any> {
@@ -64,6 +65,16 @@ export class AdminService {
 
   deleteRoute(id: number): Observable<any> {
     return this.http.delete(`${this.api}/routes/${id}`);
+  }
+
+  // ── Reports ────────────────────────────────────────────────────────────────
+
+  getReports(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.api}/reports`);
+  }
+
+  resolveReport(id: number): Observable<any> {
+    return this.http.put(`${this.api}/reports/${id}/status`, { status: 'Resolved' });
   }
 
   // ── Datenbank zurücksetzen (Gefahrenzone) ──────────────────────────────────

--- a/frontend/src/services/areas.service.ts
+++ b/frontend/src/services/areas.service.ts
@@ -45,7 +45,7 @@ export interface RouteComment {
   userId?: number;
   text: string;
   authorName?: string | null;
-  user?: { username?: string | null };
+  user?: { id?: number; username?: string | null };
   photoUrl?: string | null;
   createdAtUtc?: string | null;
 }
@@ -55,7 +55,7 @@ export interface AreaComment {
   userId?: number;
   text: string;
   authorName?: string | null;
-  user?: { username?: string | null };
+  user?: { id?: number; username?: string | null };
   authorPhotoUrl?: string | null;
   createdAt?: string | null;
   createdAtUtc?: string | null;


### PR DESCRIPTION
## Was wurde implementiert

### #159 — Termin-Detail inline aufklappen
- Klick auf Termin-Kopfzeile (Titel + Teilnehmeranzahl) klappt Detail auf/zu
- Beim Aufklappen: `GET /api/appointments/{id}` wird gecacht (wird nur einmal geladen)
- Zeigt: Beschreibung, Ø Grad der Gruppe (in Benutzer-Skala), Teilnehmerliste mit Usernamen

### #162 — Benutzer suchen
- Neue Seite `/climbers` mit Suchfeld und Liste aller User
- Suche filtert clientseitig nach Benutzername
- Klick auf User-Karte → öffentliches Profil `/users/:id`
- "Kletterer" Link im Navigationsmenü
- Kommentar-Autorennamen in AreaDetail + RouteDetail sind jetzt klickbare Links zu `/users/:id`

### #161 — Admin: Safety Reports verwalten
- Neuer "Reports"-Tab im Admin-Interface
- Zeigt alle Reports (Text, Schweregrad, Datum, Autor)
- Button "Als erledigt markieren" → `PUT /api/reports/{id}/status`
- Checkbox "Erledigte anzeigen" zum Einblenden von Resolved-Reports

### Bugfix: AdminService.getAreas() war durch Paginierung gebrochen
- `getAreas()` rief `/api/areas` auf und erwartete `any[]`, bekam aber `{ total, page, pageSize, items }`
- Fix: `?pageSize=100` + `.pipe(map(r => r.items))`

## Test plan
- [ ] Termin aufklappen → Teilnehmerliste und Durchschnittsgrad sichtbar
- [ ] `/climbers` → Suchfeld filtert live nach Benutzername
- [ ] Kommentar-Autor anklicken → öffnet öffentliches Profil
- [ ] Admin → Tab "Reports" → Reports laden und als erledigt markieren
- [ ] Admin → Tab "Gebiete" → Gebiete laden wieder korrekt (Bugfix)