### PR TITLE
feat: Favoriten-System + Doku-Update (closes #93, #3, #16, #18, #65, #66)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,164 @@
-# Architektur – ClimbConnect (Entwurf)
+# Architektur – ClimbConnect
 
-## Komponentenübersicht
+## Systemübersicht
 
-- Frontend: Angular (TypeScript)
-- Backend: ASP.NET Core Minimal API
-- Datenbank: Oracle SQL (oder vergleichbare relationale DB)
-- Schnittstelle: REST-API (JSON)
+ClimbConnect ist eine Web-App für die Klettergemeinschaft in Oberösterreich.
+Benutzer können Klettergebiete, Sektoren und Routen einsehen, eigene Begehungen
+eintragen, Termine planen und Kommentare hinterlassen.
 
-> Detailausarbeitung folgt im Verlauf der Implementierung.
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        Browser (Client)                          │
+│                   Angular 20 (TypeScript, SPA)                   │
+│  ┌────────────┐  ┌────────────┐  ┌──────────────┐  ┌─────────┐ │
+│  │  Areas /   │  │  Progress  │  │ Appointments │  │  Admin  │ │
+│  │  Routes    │  │  Profile   │  │  Climbers    │  │  Panel  │ │
+│  └────────────┘  └────────────┘  └──────────────┘  └─────────┘ │
+│           │             JWT-Token (localStorage)                  │
+└───────────┼──────────────────────────────────────────────────────┘
+            │ HTTP/REST (JSON)
+┌───────────▼──────────────────────────────────────────────────────┐
+│                    .NET 8 Minimal API (Backend)                   │
+│  ┌──────────────────────────────────────────────────────────────┐ │
+│  │  AuthEndpoints  AreaEndpoints  RouteEndpoints  ...           │ │
+│  │  ProgressEndpoints  AppointmentEndpoints  CommentEndpoints   │ │
+│  │  ReportEndpoints  UserEndpoints  UploadEndpoints             │ │
+│  └──────────────────────────────────────────────────────────────┘ │
+│  ┌──────────────────┐  ┌────────────────────────────────────────┐ │
+│  │  AppDbContext    │  │  GradeConversionService                │ │
+│  │  (EF Core 8)     │  │  (Franz. → UIAA → Amerikanisch)       │ │
+│  └──────────────────┘  └────────────────────────────────────────┘ │
+└───────────┬──────────────────────────────────────────────────────┘
+            │ EF Core (SQLite)
+┌───────────▼──────────────────────────────────────────────────────┐
+│                       SQLite-Datenbank                            │
+│  Users  Areas  Sectors  Routes  Progresses  Appointments         │
+│  AppointmentUsers  Comments  Reports                             │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Stack
+
+| Schicht      | Technologie                                 |
+|-------------|---------------------------------------------|
+| Frontend    | Angular 20, TypeScript, Standalone Components |
+| Backend     | .NET 8 Minimal API, C#                      |
+| ORM         | Entity Framework Core 8                     |
+| Datenbank   | SQLite (Entwicklung & Produktion)           |
+| Auth        | JWT (eigenes System, HS256)                 |
+| Tests       | xUnit, Microsoft.AspNetCore.Mvc.Testing, EF InMemory |
+| CI/CD       | GitHub Actions                              |
+
+## Backend-Struktur
+
+```
+backend/ClimbConnect.API/
+├── Data/
+│   └── AppDbContext.cs          – EF Core DbContext, 9 DbSets
+├── Dtos/                        – Request-Payloads (Records mit DataAnnotations)
+├── Extensions/                  – Endpoint-Klassen (je eine Datei pro Ressource)
+│   ├── AuthEndpoints.cs         – POST /register, POST /login
+│   ├── AreaEndpoints.cs         – CRUD /api/areas (Admin: schreiben)
+│   ├── SectorEndpoints.cs       – CRUD /api/sectors
+│   ├── RouteEndpoints.cs        – CRUD /api/routes, Community-Grad
+│   ├── ProgressEndpoints.cs     – CRUD /api/progress (User: eigene)
+│   ├── AppointmentEndpoints.cs  – CRUD /api/appointments, subscribe/unsubscribe
+│   ├── CommentEndpoints.cs      – Kommentare zu Areas und Routen
+│   ├── ReportEndpoints.cs       – Safety Reports (User erstellt, Admin löst auf)
+│   ├── UserEndpoints.cs         – Profil, Statistiken, Passwort, öffentliche Profile
+│   └── UploadEndpoints.cs       – POST /api/upload (Bild-Upload)
+├── Migrations/                  – EF Core Migrationen
+├── Models/                      – Entitäts-Klassen
+├── Services/
+│   └── GradeConversionService.cs – Grad-Konversion: Französisch ↔ UIAA ↔ Amerikanisch
+└── Program.cs                   – App-Konfiguration, Middleware, JWT, Swagger
+```
+
+## Frontend-Struktur
+
+```
+frontend/src/
+├── app/
+│   ├── admin/                   – Admin-Panel (Gebiete, Sektoren, Routen, Reports)
+│   ├── features/
+│   │   ├── areas/               – Gebietsliste + Area-Detailseite
+│   │   ├── appointments/        – Termin-Formular
+│   │   ├── climbers/            – Benutzer suchen
+│   │   ├── auth/                – Login + Registrierung
+│   │   ├── home/                – Startseite
+│   │   ├── progress/            – Begehung eintragen/bearbeiten
+│   │   ├── routes/              – Route-Detailseite
+│   │   └── users/               – Öffentliches Profil
+│   ├── guards/
+│   │   └── auth-role.guard.ts   – Routen-Guard (eingeloggt, Admin)
+│   ├── interceptors/
+│   │   ├── jwt.interceptor.ts   – Fügt Bearer-Token zu jedem Request hinzu
+│   │   └── error.interceptor.ts – 401 → /login, 403 → /forbidden
+│   ├── menu/                    – Navigationsleiste
+│   └── user-profile/            – Eigenes Profil, Statistiken, Passwort
+├── services/
+│   ├── areas.service.ts         – HTTP-Calls für Areas, Routes, Progress, Comments, Reports
+│   ├── auth.service.ts          – Login/Logout, JWT-Parsing, Rollenverwaltung
+│   ├── admin.service.ts         – Admin-spezifische HTTP-Calls
+│   ├── favorites.service.ts     – Favoriten-Verwaltung (localStorage)
+│   └── user.service.ts          – Profil, Statistiken, Passwort
+└── environments/                – API-URL pro Umgebung
+```
+
+## Rollen
+
+| Rolle   | Kann                                                               |
+|---------|--------------------------------------------------------------------|
+| `admin` | Gebiete/Sektoren/Routen anlegen, bearbeiten, löschen; Reports verwalten |
+| `user`  | Lesen, Fortschritt eintragen, Kommentare, Termine erstellen/beitreten |
+
+Rollen werden beim Login als JWT-Claim (`role`) gesetzt und vom Backend bei jedem
+Request über `.RequireAuthorization("Admin")` / `.RequireAuthorization("User")` geprüft.
+
+## Authentifizierung
+
+```
+Browser                          Backend
+  │                                │
+  │  POST /api/auth/login           │
+  │  { email, password }  ────────► │
+  │                                 │  BCrypt.Verify → JWT erzeugen
+  │  { token: "eyJ..." }  ◄──────── │
+  │                                 │
+  │  GET /api/areas                 │
+  │  Authorization: Bearer eyJ... ► │
+  │                                 │  JWT validieren → userId aus Claim
+  │  { total, page, items: [...] }  │
+  │  ◄────────────────────────────  │
+```
+
+## Grad-Konversion
+
+Routen werden intern in der **französischen Skala** gespeichert (z. B. `6a`, `7b+`).
+Beim Abrufen wird über `?scale=french|uiaa|american` die gewünschte Ausgabeskala übergeben.
+
+`GradeConversionService` enthält eine geordnete Liste aller Französischen Grade und
+Mappings zu UIAA und Amerikanisch. Der Community-Grad berechnet sich aus dem
+Durchschnitt aller subjektiven Gradbewertungen der Benutzer.
+
+## Paginierung
+
+Listen-Endpoints (`GET /api/areas`, `GET /api/routes`, `GET /api/progress/me`)
+unterstützen `?page=1&pageSize=20` und geben zurück:
+
+```json
+{
+  "total": 42,
+  "page": 1,
+  "pageSize": 20,
+  "items": [...]
+}
+```
+
+## Integrationstests
+
+Das Projekt `backend/ClimbConnect.Tests` enthält xUnit-Tests mit einer
+In-Memory-SQLite-Datenbank pro Testklasse. Testabdeckung:
+- `AuthTests` – Register, Login, Validierung
+- `AreaTests` – CRUD, Authentifizierung, Paginierung
+- `ProgressTests` – Begehungen, Eigentümerschutz

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -1,0 +1,86 @@
+# Git- und Branch-Workflow – ClimbConnect
+
+## Grundregel
+
+**Nie direkt auf `main` pushen.** Jede Änderung läuft über einen Feature-Branch
+und einen Pull Request.
+
+## Branch-Konvention
+
+| Prefix     | Wann verwenden                          | Beispiel                        |
+|------------|------------------------------------------|---------------------------------|
+| `feat/`    | Neues Feature                            | `feat/favoriten-localStorage`   |
+| `fix/`     | Bugfix                                   | `fix/bugs-153-152-155`          |
+| `refactor/`| Code-Umbau ohne neue Funktionalität      | `refactor/program-cs-aufteilen` |
+| `docs/`    | Nur Dokumentation                        | `docs/architecture-update`      |
+| `test/`    | Tests hinzufügen                         | `test/integrationstests`        |
+
+Branch-Namen in Kleinbuchstaben, Worte mit Bindestrich getrennt.
+
+## Workflow Schritt für Schritt
+
+```
+1. main aktualisieren
+   git checkout main
+   git pull origin main
+
+2. Feature-Branch erstellen
+   git checkout -b feat/mein-feature
+
+3. Implementieren, committen
+   git add <dateien>
+   git commit -m "feat: kurze Beschreibung (closes #123)"
+
+4. Pushen
+   git push origin feat/mein-feature
+
+5. Pull Request auf GitHub erstellen
+   → Base: main  ←  Compare: feat/mein-feature
+   → Titel: aussagekräftig, Issue-Nummer im Body
+   → Review abwarten, dann mergen
+
+6. Branch nach Merge löschen (GitHub macht das automatisch)
+```
+
+## Commit-Messages
+
+Format: `<typ>: <kurze Beschreibung> [(closes #NNN)]`
+
+| Typ        | Bedeutung                              |
+|------------|----------------------------------------|
+| `feat`     | Neues Feature                          |
+| `fix`      | Bugfix                                 |
+| `refactor` | Umbau ohne funktionale Änderung        |
+| `docs`     | Nur Dokumentation                      |
+| `test`     | Tests hinzufügen oder reparieren       |
+| `chore`    | Build, Abhängigkeiten, Konfiguration   |
+
+Beispiele:
+```
+feat: Favoriten-System mit localStorage (closes #93)
+fix: bevorzugte Gradskala in PublicProfile verwenden (closes #155)
+refactor: Program.cs in separate Endpoint-Klassen aufteilen
+docs: ARCHITECTURE.md und GIT_WORKFLOW.md vervollständigen
+```
+
+## Beispiel-Pull-Request
+
+**Titel:** `feat: Termin-Detail inline aufklappen (closes #159)`
+
+**Body:**
+```markdown
+## Was wurde gemacht
+- Klick auf Termin klappt Detail mit Teilnehmerliste und Ø Grad auf
+- GET /api/appointments/{id} wird beim ersten Aufklappen geladen und gecacht
+
+## Test plan
+- [ ] Termin aufklappen → Teilnehmerliste sichtbar
+- [ ] Durchschnittsgrad erscheint wenn Teilnehmer Begehungen haben
+```
+
+## Wichtige Regeln
+
+- Kein `--force`-Push auf `main`
+- Kein `git commit --no-verify` (Hooks nicht umgehen)
+- Branches **immer** von aktuellem `main` abzweigen
+- Issue-Nummern in Commit-Messages → GitHub schließt Issues automatisch beim Merge

--- a/frontend/src/app/features/areas/areas-page.component.html
+++ b/frontend/src/app/features/areas/areas-page.component.html
@@ -48,6 +48,15 @@
         Zurücksetzen
       </button>
     }
+
+    <button
+      type="button"
+      class="toolbar-button"
+      [class.primary-button]="showOnlyFavorites"
+      [class.ghost-button]="!showOnlyFavorites"
+      (click)="showOnlyFavorites = !showOnlyFavorites">
+      {{ showOnlyFavorites ? '♥ Alle anzeigen' : '♡ Favoriten' }}
+    </button>
   </form>
 
   @if (loading) {
@@ -78,15 +87,23 @@
     <div class="section-title">
       <div>
         <p class="eyebrow">Übersicht</p>
-        <h2>Verfügbare Klettergebiete</h2>
+        <h2>{{ showOnlyFavorites ? 'Meine Favoriten' : 'Verfügbare Klettergebiete' }}</h2>
       </div>
 
-      <span>{{ areas.length }} Treffer</span>
+      <span>{{ displayedAreas.length }} Treffer</span>
     </div>
+
+    @if (showOnlyFavorites && displayedAreas.length === 0) {
+      <div class="empty-box state-box">
+        <h2>Keine Favoriten gespeichert</h2>
+        <p>Klicke auf das ♡-Symbol bei einem Gebiet um es zu speichern.</p>
+        <button type="button" (click)="showOnlyFavorites = false">Alle Gebiete anzeigen</button>
+      </div>
+    } @else {
 
     <div class="areas-grid">
 
-      @for (area of areas; track area.id) {
+      @for (area of displayedAreas; track area.id) {
 
         <a class="area-card" [routerLink]="['/areas', area.id]">
 
@@ -102,6 +119,15 @@
             <span class="image-badge">
               {{ area.todayVisitors ?? 0 }} heute
             </span>
+
+            <button
+              type="button"
+              class="favorite-btn"
+              [class.is-favorite]="favoritesService.isFavorite(area.id)"
+              [title]="favoritesService.isFavorite(area.id) ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'"
+              (click)="toggleFavorite($event, area.id)">
+              {{ favoritesService.isFavorite(area.id) ? '♥' : '♡' }}
+            </button>
           </div>
 
           <div class="area-content">
@@ -126,6 +152,8 @@
       }
 
     </div>
+
+    }
 
   }
 

--- a/frontend/src/app/features/areas/areas-page.component.ts
+++ b/frontend/src/app/features/areas/areas-page.component.ts
@@ -1,18 +1,23 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { CommonModule } from '@angular/common';
 import { Area, AreasService } from '../../../services/areas.service';
+import { FavoritesService } from '../../../services/favorites.service';
 
 @Component({
   selector: 'app-areas-page',
   standalone: true,
-  imports: [RouterLink, FormsModule],
+  imports: [RouterLink, FormsModule, CommonModule],
   templateUrl: './areas-page.component.html',
   styleUrl: './areas-page.component.css',
 })
 export class AreasPageComponent implements OnInit {
 
   private areasService = inject(AreasService);
+  favoritesService = inject(FavoritesService);
+
+  showOnlyFavorites = false;
 
   areas: Area[] = [];
   loading = true;
@@ -79,5 +84,16 @@ export class AreasPageComponent implements OnInit {
 
   getInitial(area: Area): string {
     return area.name?.trim().charAt(0).toUpperCase() || '?';
+  }
+
+  get displayedAreas(): Area[] {
+    if (!this.showOnlyFavorites) return this.areas;
+    return this.areas.filter(a => this.favoritesService.isFavorite(a.id));
+  }
+
+  toggleFavorite(event: Event, areaId: number): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.favoritesService.toggle(areaId);
   }
 }

--- a/frontend/src/services/favorites.service.ts
+++ b/frontend/src/services/favorites.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+
+const STORAGE_KEY = 'cc_favorite_areas';
+
+@Injectable({ providedIn: 'root' })
+export class FavoritesService {
+
+  private ids: Set<number>;
+
+  constructor() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    this.ids = raw ? new Set(JSON.parse(raw)) : new Set();
+  }
+
+  isFavorite(areaId: number): boolean {
+    return this.ids.has(areaId);
+  }
+
+  toggle(areaId: number): void {
+    if (this.ids.has(areaId)) {
+      this.ids.delete(areaId);
+    } else {
+      this.ids.add(areaId);
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...this.ids]));
+  }
+
+  get favoriteIds(): number[] {
+    return [...this.ids];
+  }
+}


### PR DESCRIPTION
## Was wurde gemacht

### #93 — Favoriten speichern (localStorage)
- Neuer `FavoritesService` speichert Gebiet-IDs im `localStorage` (Schlüssel: `cc_favorite_areas`)
- Herz-Icon (♡/♥) auf jeder Gebietskarte — Klick speichert/entfernt Favorit ohne Navigation
- "Favoriten"-Button in der Toolbar filtert die Gebietsliste auf gespeicherte Favoriten
- Leerer Favoriten-Zustand mit Hinweistext

### #3 / #18 / #65 / #66 — Architektur-Dokumentation
`docs/ARCHITECTURE.md` komplett neu geschrieben:
- ASCII-Systemdiagramm (Browser → API → SQLite)
- Stack-Tabelle mit allen Technologien
- Backend-Verzeichnisstruktur mit Erklärungen
- Frontend-Verzeichnisstruktur mit Erklärungen
- Rollen- und Authentifizierungsfluss
- Grad-Konversionssystem erklärt
- Paginierungs-Response-Format
- Testabdeckung dokumentiert

### #16 — Git-Workflow dokumentieren
Neue Datei `docs/GIT_WORKFLOW.md`:
- Branch-Konventionen (feat/, fix/, refactor/, docs/, test/)
- Schritt-für-Schritt Workflow
- Commit-Message-Format mit Typ-Tabelle
- Beispiel-PR
- Wichtige Regeln (kein force-push, kein --no-verify)

## Test plan
- [ ] Gebietsliste öffnen → Herz-Icon auf jeder Karte sichtbar
- [ ] Herz anklicken → wird gefüllt (♥), kein Seitennavigation
- [ ] "Favoriten"-Button → zeigt nur markierte Gebiete
- [ ] Seite neu laden → Favoriten bleiben erhalten (localStorage)
- [ ] Leere Favoriten → Hinweistext erscheint