### PR TITLE
feat: Gebiet-Besuche in Profil-Statistik

### DIFF
--- a/backend/ClimbConnect.API/Extensions/UserEndpoints.cs
+++ b/backend/ClimbConnect.API/Extensions/UserEndpoints.cs
@@ -99,12 +99,20 @@ public static class UserEndpoints
                 })
                 .ToList();
 
+            // Besuche pro Gebiet: wie oft wurde in jedem Gebiet eine Route geklettert
+            var areaVisits = ascents
+                .GroupBy(p => new { p.Route.Sector.Area.Id, p.Route.Sector.Area.Name })
+                .OrderByDescending(g => g.Count())
+                .Select(g => new { AreaId = g.Key.Id, AreaName = g.Key.Name, Count = g.Count() })
+                .ToList();
+
             return Results.Ok(new
             {
                 TotalClimbed     = ascents.Count,
                 OpenProjects     = projects.Count,
                 FavoriteArea     = favoriteArea,
-                GradeProgression = gradeProgression
+                GradeProgression = gradeProgression,
+                AreaVisits       = areaVisits
             });
         })
         .WithName("GetUserStats")

--- a/frontend/src/app/user-profile/user-profile.component.css
+++ b/frontend/src/app/user-profile/user-profile.component.css
@@ -467,6 +467,62 @@ select:focus {
   cursor: not-allowed;
 }
 
+/* ── Gebiets-Besuche ─────────────────────────────────────────────────────── */
+
+.area-visits-card {
+  grid-column: 1 / -1;
+}
+
+.area-visits-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.area-visit-row {
+  display: grid;
+  grid-template-columns: 180px 1fr 48px;
+  align-items: center;
+  gap: 12px;
+}
+
+.area-visit-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.area-visit-name:hover {
+  text-decoration: underline;
+}
+
+.area-visit-bar-wrap {
+  background: #e5e7eb;
+  border-radius: 4px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.area-visit-bar {
+  height: 100%;
+  background: #2563eb;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+  min-width: 4px;
+}
+
+.area-visit-count {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #374151;
+  text-align: right;
+}
+
 @media (max-width: 700px) {
   .appointment-main,
   .appointment-actions {

--- a/frontend/src/app/user-profile/user-profile.component.html
+++ b/frontend/src/app/user-profile/user-profile.component.html
@@ -114,10 +114,35 @@
 
         <div class="stat-item">
           <span>Lieblingsgebiet</span>
-          <strong>{{ stats.favoriteArea }}</strong>
+          <strong>{{ stats.favoriteArea || '-' }}</strong>
         </div>
       </div>
     </aside>
+
+    @if (areaVisits.length > 0) {
+      <aside class="profile-card area-visits-card">
+        <h2>Meine Gebiete</h2>
+        <p class="eyebrow">Wie oft warst du wo?</p>
+
+        <div class="area-visits-list">
+          @for (visit of areaVisits; track visit.areaId) {
+            @let maxCount = areaVisits[0].count;
+            <div class="area-visit-row">
+              <a class="area-visit-name" [routerLink]="['/areas', visit.areaId]">
+                {{ visit.areaName }}
+              </a>
+              <div class="area-visit-bar-wrap">
+                <div
+                  class="area-visit-bar"
+                  [style.width.%]="(visit.count / maxCount) * 100">
+                </div>
+              </div>
+              <span class="area-visit-count">{{ visit.count }}×</span>
+            </div>
+          }
+        </div>
+      </aside>
+    }
 
   </div>
 

--- a/frontend/src/app/user-profile/user-profile.component.ts
+++ b/frontend/src/app/user-profile/user-profile.component.ts
@@ -41,6 +41,8 @@ export class UserProfileComponent implements OnInit, AfterViewInit {
     favoriteArea: '-'
   };
 
+  areaVisits: { areaId: number; areaName: string; count: number }[] = [];
+
   gradeProgression: { month: string; grade: string }[] = [];
   chartReady = false;
   private chart: Chart | null = null;
@@ -95,6 +97,7 @@ export class UserProfileComponent implements OnInit, AfterViewInit {
         this.stats.openProjects = s.openProjects ?? 0;
         this.stats.favoriteArea = s.favoriteArea ?? '-';
         this.gradeProgression   = s.gradeProgression ?? [];
+        this.areaVisits         = s.areaVisits ?? [];
         this.buildChart();
       },
       error: () => {}

--- a/frontend/src/services/user.service.ts
+++ b/frontend/src/services/user.service.ts
@@ -7,6 +7,7 @@ export interface UserStats {
   openProjects: number;
   favoriteArea: string | null;
   gradeProgression: { month: string; grade: string }[];
+  areaVisits: { areaId: number; areaName: string; count: number }[];
 }
 
 export interface UserListItem {


### PR DESCRIPTION
## Was wurde gemacht

Auf Wunsch: Im eigenen Profil sieht man jetzt wie oft man in welchem Gebiet war.

### Backend
`GET /api/users/{id}/stats` gibt jetzt zusätzlich `areaVisits` zurück:
```json
"areaVisits": [
  { "areaId": 1, "areaName": "Gmundnerberg", "count": 12 },
  { "areaId": 3, "areaName": "Traunstein",   "count":  5 }
]
```
Sortiert nach Anzahl Begehungen (häufigstes Gebiet zuerst).

### Frontend
Neue Karte "Meine Gebiete" im Profil — erscheint nur wenn Begehungen vorhanden:
- Jede Zeile: Gebietsname (klickbar → Detailseite) + Balken + Anzahl
- Balken ist relativ zum häufigsten Gebiet (immer 100%)
- CSS mit Übergängen

## Test plan
- [ ] Profil öffnen nach einigen Begehungen → Karte "Meine Gebiete" erscheint
- [ ] Balkenbreite entspricht dem Verhältnis der Besuche
- [ ] Klick auf Gebietsname → navigiert zur Detailseite
- [ ] Ohne Begehungen → Karte wird nicht angezeigt